### PR TITLE
fixed chat textarea overflow

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -13,6 +13,8 @@ export const ChatInput: FC<Props> = ({ onSend, messageIsStreaming }) => {
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const chatBoxMaxHeight = 400; //chat box max height in pixels
+
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     if (value.length > 4000) {
@@ -45,8 +47,21 @@ export const ChatInput: FC<Props> = ({ onSend, messageIsStreaming }) => {
 
   useEffect(() => {
     if (textareaRef && textareaRef.current) {
+      let chatBoxHeight = textareaRef.current.scrollHeight;
+      if (chatBoxHeight > chatBoxMaxHeight) {
+        textareaRef.current.style.overflowY = "auto";
+      } else {
+        textareaRef.current.style.overflowY = "hidden";
+      }
+
       textareaRef.current.style.height = "inherit";
-      textareaRef.current.style.height = `${textareaRef.current?.scrollHeight}px`;
+
+      // Reset textarea height if there is no content
+      if (content) {
+        textareaRef.current.style.height = `${chatBoxHeight}px`;
+      } else {
+        textareaRef.current.style.height = "auto";
+      }
     }
   }, [content]);
 
@@ -59,8 +74,8 @@ export const ChatInput: FC<Props> = ({ onSend, messageIsStreaming }) => {
           style={{
             resize: "none",
             bottom: `${textareaRef?.current?.scrollHeight}px`,
-            maxHeight: "400px",
-            overflow: "auto"
+            maxHeight: `${chatBoxMaxHeight}px`,
+            overflow: "hidden",
           }}
           placeholder="Type a message..."
           value={content}


### PR DESCRIPTION
Hi folks,

I'm a UI/UX developer.
This is my first contribution to this repo..tiny change but an important one :)

Hiding the overflow-y in a textarea can be beneficial for the UI/UX because it provides a cleaner and more consistent user interface. When the overflow-y is hidden, the textarea will only display the visible text and will not show any scrollbars or other elements that could clutter the interface.

This can be particularly useful when designing interfaces for mobile devices or small screens, where space is at a premium. By hiding the overflow-y, you can ensure that the textarea takes up only the necessary space and does not interfere with other elements on the page.

In addition, hiding the overflow-y can also help to prevent distractions and improve the user's focus on the content they are typing. When scrollbars or other elements are visible, they can be a distraction and may draw the user's attention away from the task at hand.

### Changes:
![1](https://user-images.githubusercontent.com/73870784/226165879-006f661c-db79-4f4e-a9a5-f130eea235b2.gif)

