### PR TITLE
feat: Add conditional search input for conversation list

### DIFF
--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Conversation } from "@/types";
-import { IconArrowBarLeft, IconPlus } from "@tabler/icons-react";
-import { FC } from "react";
+import { IconArrowBarLeft, IconPlus, IconX } from "@tabler/icons-react";
+import { FC, useState } from "react";
 import { Conversations } from "./Conversations";
 import { SidebarSettings } from "./SidebarSettings";
 
@@ -20,6 +20,18 @@ interface Props {
 }
 
 export const Sidebar: FC<Props> = ({ loading, conversations, lightMode, selectedConversation, apiKey, onNewConversation, onToggleLightMode, onSelectConversation, onDeleteConversation, onToggleSidebar, onRenameConversation, onApiKeyChange }) => {
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+  };
+  const filteredConversations = conversations.filter((conversation) =>
+    conversation.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+  const clearSearch = () => {
+    setSearchTerm("");
+  };
+
   return (
     <div className={`flex flex-col bg-[#202123] min-w-full sm:min-w-[260px] sm:max-w-[260px] z-10`}>
       <div className="flex items-center h-[60px] sm:pl-2 px-2">
@@ -41,10 +53,29 @@ export const Sidebar: FC<Props> = ({ loading, conversations, lightMode, selected
         />
       </div>
 
+      {conversations && conversations.length > 1 && (
+        <div className="flex items-center h-[60px] sm:pl-2 px-2">
+          <input
+              className="flex-1 bg-[#202123] border border-neutral-600 text-sm rounded-lg px-4 text-white"
+              type="text"
+              placeholder="Search conversations..."
+              value={searchTerm}
+              onChange={onSearchChange}
+          />
+          {searchTerm && (
+              <IconX
+                  className="mr-2 p-1 text-neutral-300 cursor-pointer hover:text-neutral-400"
+                  size={20}
+                  onClick={clearSearch}
+              />
+          )}
+        </div>
+      )}
+
       <div className="flex-1 overflow-auto">
         <Conversations
           loading={loading}
-          conversations={conversations}
+          conversations={filteredConversations}
           selectedConversation={selectedConversation}
           onSelectConversation={onSelectConversation}
           onDeleteConversation={onDeleteConversation}


### PR DESCRIPTION
- Implement a search input field for filtering conversations in the sidebar when there are more than one conversation in the list. 
- The search input field is now displayed conditionally based on the number of conversations. 
- Additionally, a clear button has been added to easily clear the search input field.

Playground : https://chatbot-gvd6lammv-mckay-personal.vercel.app

<img width="1672" alt="Screenshot 2023-03-19 at 2 57 01 PM" src="https://user-images.githubusercontent.com/20665149/226200778-f9151045-3ae7-4f42-98e0-efe0dc43a037.png">
<img width="1653" alt="Screenshot 2023-03-19 at 2 41 08 PM" src="https://user-images.githubusercontent.com/20665149/226200690-64b43231-0825-4541-9562-f9b8035424ca.png">
<img width="440" alt="Screenshot 2023-03-19 at 2 45 31 PM" src="https://user-images.githubusercontent.com/20665149/226200693-7f9cd1c0-3e8f-4482-b027-3c5ad8a2b5bf.png">
