### PR TITLE
remove ENV var from vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Modify the system prompt in `utils/index.ts`.
 
 Host your own live version of Chatbot UI with Vercel.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmckaywrigley%2Fchatbot-ui&env=OPENAI_API_KEY&envDescription=Your%20OpenAI%20API%20Key.%20Chat%20will%20not%20work%20if%20you%20don't%20provide%20it.)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmckaywrigley%2Fchatbot-ui&envDescription=Your%20OpenAI%20API%20Key.%20Chat%20will%20not%20work%20if%20you%20don't%20provide%20it.)
 
 **Replit**
 


### PR DESCRIPTION
with browser-based chat UI It's not needed to provide OpenAI key to Vercel deployment

![CleanShot 2023-03-20 at 16 15 55](https://user-images.githubusercontent.com/1570963/226402575-8e13c210-182e-4518-99dc-be9d5d3bf6e2.png)
