### PR TITLE
wrap user messages

### DIFF
--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -20,7 +20,7 @@ export const ChatMessage: FC<Props> = ({ message, lightMode }) => {
 
         <div className="prose dark:prose-invert mt-[-2px]">
           {message.role === "user" ? (
-            <div className="prose dark:prose-invert whitespace-pre">
+            <div className="prose dark:prose-invert whitespace-pre-wrap">
               {message.content}
             </div>
           ) : (


### PR DESCRIPTION
User messages were not wrapping long lines:
<img width="1046" alt="Screenshot 2023-03-20 at 11 51 26 PM" src="https://user-images.githubusercontent.com/265086/226514483-bbbe0eda-d4ec-4e57-a91f-6799b2f5fc43.png">

This PR fixes this:
<img width="927" alt="Screenshot 2023-03-20 at 11 52 05 PM" src="https://user-images.githubusercontent.com/265086/226514529-c4644174-ff51-4845-8b2e-ee139bebc7f9.png">
