### PR TITLE
Improve the error message reported to the console

### DIFF
--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -24,7 +24,8 @@ export const OpenAIStream = async (model: OpenAIModel, systemPrompt: string, key
   });
 
   if (res.status !== 200) {
-    throw new Error("OpenAI API returned an error");
+    const statusText = res.statusText; 
+    throw new Error(`OpenAI API returned an error: ${statusText}`);
   }
 
   const encoder = new TextEncoder();


### PR DESCRIPTION
Instead of 

[Error: OpenAI API returned an error]

the console will report 

[Error: OpenAI API returned an error: Too Many Requests]
