### PR TITLE
fix style issue after clicking on clear conversations button

### DIFF
--- a/components/Sidebar/ClearConversations.tsx
+++ b/components/Sidebar/ClearConversations.tsx
@@ -15,10 +15,10 @@ export const ClearConversations: FC<Props> = ({ onClearConversations }) => {
   };
 
   return isConfirming ? (
-    <div className="flex hover:bg-[#343541] py-2 px-2 rounded-md cursor-pointer w-full items-center">
+    <div className="flex hover:bg-[#343541] py-3 px-3 rounded-md cursor-pointer w-full items-center">
       <IconTrash size={16} />
 
-      <div className="ml-2 flex-1 text-left text-white">Are you sure?</div>
+      <div className="ml-3 flex-1 text-left text-white">Are you sure?</div>
 
       <div className="flex w-[40px]">
         <IconCheck


### PR DESCRIPTION
related to issue #88 
there is a small difference in the spaces of the button after confirming which leads to an unexpected animation in the sidebar settings