### PR TITLE
Name conversations automatically #86

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,6 +81,16 @@ export default function Home() {
         return;
       }
 
+      if (updatedConversation.messages.length === 1) {
+        const {content} = message
+        const customName = content.length > 30 ? content.substring(0, 30) + "..." : content;
+
+        updatedConversation = {
+          ...updatedConversation,
+          name: customName
+        };
+      }
+
       setLoading(false);
 
       const reader = data.getReader();


### PR DESCRIPTION
after sending the message and making sure no error occurred, I changed the current conversation's name to be similar to the subject of the conversation by taking a substring (the first 30 characters) from the message, similar to what Actual ChatGPT does

fixes #86

> you can update the header of the page as well if needed for future