### PR TITLE
add k8s config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+include .env
+
+.PHONY: all
+
+build:
+	docker build -t chatbot-ui .
+
+run:
+	export $(cat .env | xargs)
+	docker stop chatbot-ui || true && docker rm chatbot-ui || true
+	docker run --name chatbot-ui --rm -e OPENAI_API_KEY=${OPENAI_API_KEY} -p 3000:3000 chatbot-ui
+
+logs:
+	docker logs -f chatbot-ui
+
+push:
+	docker tag chatbot-ui:latest ${DOCKER_USER}/chatbot-ui:${DOCKER_TAG}
+	docker push ${DOCKER_USER}/chatbot-ui:${DOCKER_TAG}

--- a/k8s/chatbot-ui.yaml
+++ b/k8s/chatbot-ui.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chatbot-ui
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: chatbot-ui
+  name: chatbot-ui
+type: Opaque
+data:
+  OPENAI_API_KEY: <base64 encoded key>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: chatbot-ui
+  name: chatbot-ui
+  labels:
+    app: chatbot-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chatbot-ui
+  template:
+    metadata:
+      labels:
+        app: chatbot-ui
+    spec:
+      containers:
+        - name: chatbot-ui
+          image: <docker user>/chatbot-ui:latest
+          resources: {}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: chatbot-ui
+                  key: OPENAI_API_KEY
+---
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: chatbot-ui
+  name: chatbot-ui
+  labels:
+    app: chatbot-ui
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+  selector:
+    app: chatbot-ui
+  type: ClusterIP


### PR DESCRIPTION
- add Makefile

Makefile expects .env file to be also present in on the system with the following vars - 

OPENAI_API_KEY=
DOCKER_USER=
DOCKER_TAG=

- add baseline k8s config

Baseline k8s config includes secret, deployment and service definition only. If running on local cluster, additional entries can be made to include cronjobs (e.g. update cloudflare), nginx ingress, etc. 