### PR TITLE
fix: change message edit logic

### DIFF
--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -32,7 +32,9 @@ export const ChatMessage: FC<Props> = ({ message, messageIndex, lightMode, onEdi
   };
 
   const handleEditMessage = () => {
-    onEditMessage({ ...message, content: messageContent }, messageIndex);
+    if (message.content != messageContent) {
+      onEditMessage({ ...message, content: messageContent }, messageIndex);
+    }
     setIsEditing(false);
   };
 


### PR DESCRIPTION
### Desciption
This commit change message edit logic

**Before:**
If the message is not edited and "Edit & Submit" is pressed, then the answer will be regenerated, even if nothing has changed
**After:**
If the edited message isn't different from the original message and "Edit & Submit" is pressed, then do nothing.