### PR TITLE
Skip corrupted conversationHistory item to prevent app crashes

### DIFF
--- a/utils/app/clean.ts
+++ b/utils/app/clean.ts
@@ -39,21 +39,25 @@ export const cleanConversationHistory = (history: Conversation[]) => {
   // added system prompt for each conversation (3/21/23)
   // added folders (3/23/23)
 
-  let updatedHistory = [...history];
+  return history.reduce((acc: Conversation[], conversation) => {
+    try {
+      if (!conversation.model) {
+        conversation.model = OpenAIModels[OpenAIModelID.GPT_3_5];
+      }
 
-  updatedHistory.forEach((conversation) => {
-    if (!conversation.model) {
-      conversation.model = OpenAIModels[OpenAIModelID.GPT_3_5];
+      if (!conversation.prompt) {
+        conversation.prompt = DEFAULT_SYSTEM_PROMPT;
+      }
+
+      if (!conversation.folderId) {
+        conversation.folderId = 0;
+      }
+
+      acc.push(conversation);
+      return acc;
+    } catch (error) {
+      console.warn(`error while cleaning conversations' history. Removing culprit`, error);
     }
-
-    if (!conversation.prompt) {
-      conversation.prompt = DEFAULT_SYSTEM_PROMPT;
-    }
-
-    if (!conversation.folderId) {
-      conversation.folderId = 0;
-    }
-  });
-
-  return updatedHistory;
+    return acc;
+  }, []);
 };


### PR DESCRIPTION
## Motivation

While experimenting with the app code, I discovered that (accidentally) setting `conversationHistory` to `[null]` in localStorage caused the app to crash on subsequent reloads due to an error in the clean.ts module.

Currently, the only solution to this issue is for the user to clear their localStorage, which is inconvenient and not ideal.


## Proposed change

To solve this problem, this pull request proposes skipping any corrupted conversationHistory items instead of crashing the app. This approach allows us to preserve the rest of the localStorage data and provide a better user experience.