### PR TITLE
fix tab order for conversation buttons.

### DIFF
--- a/components/Sidebar/Conversations.tsx
+++ b/components/Sidebar/Conversations.tsx
@@ -13,8 +13,8 @@ interface Props {
 
 export const Conversations: FC<Props> = ({ loading, conversations, selectedConversation, onSelectConversation, onDeleteConversation, onUpdateConversation }) => {
   return (
-    <div className="flex flex-col-reverse gap-1 w-full pt-2">
-      {conversations.map((conversation, index) => (
+    <div className="flex flex-col gap-1 w-full pt-2">
+      {conversations.slice().reverse().map((conversation, index) => (
         <ConversationComponent
           key={index}
           selectedConversation={selectedConversation}


### PR DESCRIPTION
sort the data, not the UI. buttons are now tab-able from the top down. 

before:
https://user-images.githubusercontent.com/5056972/227753230-6802113a-f0d3-4320-851c-80f4e94d1948.mp4

after:
https://user-images.githubusercontent.com/5056972/227753234-0ee18648-8a44-4d9f-a327-487c99535202.mp4

fixes #175 