### PR TITLE
chore: delete code light theme, like chatgpt

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -30,7 +30,6 @@ interface Props {
   modelError: ErrorMessage | null;
   messageError: boolean;
   loading: boolean;
-  lightMode: 'light' | 'dark';
   onSend: (message: Message, deleteCount?: number) => void;
   onUpdateConversation: (
     conversation: Conversation,
@@ -49,7 +48,6 @@ export const Chat: FC<Props> = ({
   modelError,
   messageError,
   loading,
-  lightMode,
   onSend,
   onUpdateConversation,
   onEditMessage,
@@ -163,7 +161,6 @@ export const Chat: FC<Props> = ({
                     key={index}
                     message={message}
                     messageIndex={index}
-                    lightMode={lightMode}
                     onEditMessage={onEditMessage}
                   />
                 ))}

--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -12,14 +12,12 @@ import { CopyButton } from './CopyButton';
 interface Props {
   message: Message;
   messageIndex: number;
-  lightMode: 'light' | 'dark';
   onEditMessage: (message: Message, messageIndex: number) => void;
 }
 
 export const ChatMessage: FC<Props> = ({
   message,
   messageIndex,
-  lightMode,
   onEditMessage,
 }) => {
   const { t } = useTranslation('chat');
@@ -76,11 +74,10 @@ export const ChatMessage: FC<Props> = ({
 
   return (
     <div
-      className={`group ${
-        message.role === 'assistant'
+      className={`group ${message.role === 'assistant'
           ? 'border-b border-black/10 bg-gray-50 text-gray-800 dark:border-gray-900/50 dark:bg-[#444654] dark:text-gray-100'
           : 'border-b border-black/10 bg-white text-gray-800 dark:border-gray-900/50 dark:bg-[#343541] dark:text-gray-100'
-      }`}
+        }`}
       style={{ overflowWrap: 'anywhere' }}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
@@ -138,11 +135,10 @@ export const ChatMessage: FC<Props> = ({
 
               {(isHovering || window.innerWidth < 640) && !isEditing && (
                 <button
-                  className={`absolute ${
-                    window.innerWidth < 640
+                  className={`absolute ${window.innerWidth < 640
                       ? 'right-3 bottom-1'
                       : 'right-[-20px] top-[26px]'
-                  }`}
+                    }`}
                 >
                   <IconEdit
                     size={20}
@@ -161,12 +157,12 @@ export const ChatMessage: FC<Props> = ({
                 components={{
                   code({ node, inline, className, children, ...props }) {
                     const match = /language-(\w+)/.exec(className || '');
+                    
                     return !inline && match ? (
                       <CodeBlock
                         key={Math.random()}
                         language={match[1]}
                         value={String(children).replace(/\n$/, '')}
-                        lightMode={lightMode}
                         {...props}
                       />
                     ) : (

--- a/components/Markdown/CodeBlock.tsx
+++ b/components/Markdown/CodeBlock.tsx
@@ -6,18 +6,14 @@ import { IconCheck, IconClipboard, IconDownload } from '@tabler/icons-react';
 import { FC, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import {
-  oneDark,
-  oneLight,
-} from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 interface Props {
   language: string;
   value: string;
-  lightMode: 'light' | 'dark';
 }
 
-export const CodeBlock: FC<Props> = ({ language, value, lightMode }) => {
+export const CodeBlock: FC<Props> = ({ language, value }) => {
   const { t } = useTranslation('markdown');
   const [isCopied, setIsCopied] = useState<Boolean>(false);
 
@@ -65,6 +61,7 @@ export const CodeBlock: FC<Props> = ({ language, value, lightMode }) => {
     <div className="codeblock relative font-sans text-[16px]">
       <div className="flex items-center justify-between py-1.5 px-4">
         <span className="text-xs lowercase text-white">{language}</span>
+
         <div className="flex items-center">
           <button
             className="flex items-center rounded bg-none py-0.5 px-2 text-xs text-white focus:outline-none"
@@ -88,7 +85,7 @@ export const CodeBlock: FC<Props> = ({ language, value, lightMode }) => {
 
       <SyntaxHighlighter
         language={language}
-        style={lightMode === 'light' ? oneLight : oneDark}
+        style={oneDark}
         customStyle={{ margin: 0 }}
       >
         {value}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -582,7 +582,6 @@ const Home: React.FC<HomeProps> = ({ serverSideApiKeyIsSet }) => {
               messageError={messageError}
               models={models}
               loading={loading}
-              lightMode={lightMode}
               onSend={handleSend}
               onUpdateConversation={handleUpdateConversation}
               onEditMessage={handleEditMessage}


### PR DESCRIPTION
### Description
This commit delete `oneLight` theme from CodeBlock, so that only the dark theme remains, as in ChatGPT.
### Screenshots:
| Before | After | ChatGPT |
| ------- | ------ | --------- |
| ![image](https://user-images.githubusercontent.com/44939683/227761828-93938c37-dae8-4851-9756-b6fbcb3149e7.png) | ![image](https://user-images.githubusercontent.com/44939683/227761848-ec3cbaee-415d-43d0-9f8b-400d9ff02361.png) | ![image](https://user-images.githubusercontent.com/44939683/227761879-4b83fbaa-3440-4fc8-bb80-0a31c0ab38b7.png) |