### PR TITLE
feat: stylize home page & search in one bar

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -20,6 +20,7 @@ import { ChatMessage } from './ChatMessage';
 import { ErrorMessageDiv } from './ErrorMessageDiv';
 import { ModelSelect } from './ModelSelect';
 import { SystemPrompt } from './SystemPrompt';
+import { Spinner } from '../Global/Spinner';
 
 interface Props {
   conversation: Conversation;
@@ -121,11 +122,11 @@ export const Chat: FC<Props> = ({
               <>
                 <div className="mx-auto flex w-[350px] flex-col space-y-10 pt-12 sm:w-[600px]">
                   <div className="text-center text-4xl font-semibold text-gray-800 dark:text-gray-100">
-                    {models.length === 0 ? t('Loading...') : 'Chatbot UI'}
+                    {models.length === 0 ? <Spinner className='mx-auto' size='16px'/> : 'Chatbot UI'}
                   </div>
 
                   {models.length > 0 && (
-                    <div className="flex h-full flex-col space-y-4 rounded border border-neutral-500 p-4">
+                    <div className="flex h-full flex-col space-y-4 rounded border border-neutral-200 dark:border-neutral-600 p-4">
                       <ModelSelect
                         model={conversation.model}
                         models={models}

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -121,7 +121,7 @@ export const Chat: FC<Props> = ({
             {conversation.messages.length === 0 ? (
               <>
                 <div className="mx-auto flex w-[350px] flex-col space-y-10 pt-12 sm:w-[600px]">
-                  <div className="text-center text-4xl font-semibold text-gray-800 dark:text-gray-100">
+                  <div className="text-center text-3xl font-semibold text-gray-800 dark:text-gray-100">
                     {models.length === 0 ? <Spinner className='mx-auto' size='16px'/> : 'Chatbot UI'}
                   </div>
 

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -1,6 +1,7 @@
 import { OpenAIModel } from '@/types';
 import { FC } from 'react';
 import { useTranslation } from 'next-i18next';
+import { IconCaretDown } from '@tabler/icons-react';
 
 interface Props {
   model: OpenAIModel;
@@ -10,27 +11,33 @@ interface Props {
 
 export const ModelSelect: FC<Props> = ({ model, models, onModelChange }) => {
   const { t } = useTranslation('chat');
+
   return (
     <div className="flex flex-col">
       <label className="mb-2 text-left text-neutral-700 dark:text-neutral-400">
         {t('Model')}
       </label>
-      <select
-        className="focus:shadow-outline w-full cursor-pointer appearance-none rounded-lg border border-neutral-500 p-3 text-neutral-900 dark:bg-[#343541] dark:text-white"
-        placeholder={t('Select a model') || ''}
-        value={model.id}
-        onChange={(e) => {
-          onModelChange(
-            models.find((model) => model.id === e.target.value) as OpenAIModel,
-          );
-        }}
-      >
-        {models.map((model) => (
-          <option key={model.id} value={model.id}>
-            {model.name}
-          </option>
-        ))}
-      </select>
+      <div className="flex items-center w-full rounded-lg border border-neutral-200 text-neutral-900 dark:border-neutral-600 dark:bg-[#343541] dark:text-white">
+        <select
+          id='modelSelect'
+          className='border-0 bg-transparent mr-3 outline-0 p-2 cursor-pointer w-full'
+          placeholder={t('Select a model') || ''}
+          value={model.id}
+          onChange={(e) => {
+            onModelChange(
+              models.find(
+                (model) => model.id === e.target.value,
+              ) as OpenAIModel,
+            );
+          }}
+        >
+          {models.map((model) => (
+            <option key={model.id} value={model.id}>
+              {model.name}
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 };

--- a/components/Chat/SystemPrompt.tsx
+++ b/components/Chat/SystemPrompt.tsx
@@ -52,7 +52,7 @@ export const SystemPrompt: FC<Props> = ({ conversation, onChangePrompt }) => {
       </label>
       <textarea
         ref={textareaRef}
-        className="w-full rounded-lg border border-neutral-500 px-4 py-2 text-neutral-900 shadow focus:outline-none dark:border-neutral-800 dark:border-opacity-50 dark:bg-[#40414F] dark:text-neutral-100"
+        className="w-full rounded-lg border border-neutral-200 dark:border-neutral-600 px-4 py-3 text-neutral-900 focus:outline-none dark:bg-transparent dark:text-neutral-100"
         style={{
           resize: 'none',
           bottom: `${textareaRef?.current?.scrollHeight}px`,

--- a/components/Global/Spinner.tsx
+++ b/components/Global/Spinner.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+
+interface Props {
+  size?: string;
+  className?: string;
+}
+
+export const Spinner: FC<Props> = ({ className, size = '1em' }) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      className={`animate-spin ${className}`}
+      height={size}
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <line x1="12" y1="2" x2="12" y2="6"></line>
+      <line x1="12" y1="18" x2="12" y2="22"></line>
+      <line x1="4.93" y1="4.93" x2="7.76" y2="7.76"></line>
+      <line x1="16.24" y1="16.24" x2="19.07" y2="19.07"></line>
+      <line x1="2" y1="12" x2="6" y2="12"></line>
+      <line x1="18" y1="12" x2="22" y2="12"></line>
+      <line x1="4.93" y1="19.07" x2="7.76" y2="16.24"></line>
+      <line x1="16.24" y1="7.76" x2="19.07" y2="4.93"></line>
+    </svg>
+  );
+};

--- a/components/Sidebar/Search.tsx
+++ b/components/Sidebar/Search.tsx
@@ -1,13 +1,14 @@
-import { IconX } from '@tabler/icons-react';
+import { IconArrowLeft, IconX } from '@tabler/icons-react';
 import { FC } from 'react';
 import { useTranslation } from 'next-i18next';
 
 interface Props {
   searchTerm: string;
   onSearch: (searchTerm: string) => void;
+  onCloseSearch: () => void;
 }
 
-export const Search: FC<Props> = ({ searchTerm, onSearch }) => {
+export const Search: FC<Props> = ({ searchTerm, onSearch, onCloseSearch }) => {
   const { t } = useTranslation('sidebar');
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -18,10 +19,22 @@ export const Search: FC<Props> = ({ searchTerm, onSearch }) => {
     onSearch('');
   };
 
+  const exitFromSearch = () => {
+    onSearch('');
+
+    onCloseSearch();
+  }
+
   return (
-    <div className="relative flex items-center">
+    <div className="flex items-center w-full rounded-md border border-neutral-600 px-3 py-[0.70rem]">
+      <IconArrowLeft
+        className="cursor-pointer mr-3 text-neutral-300 hover:text-neutral-400"
+        size={20}
+        onClick={exitFromSearch}
+      />
+
       <input
-        className="w-full flex-1 rounded-md border border-neutral-600 bg-[#202123] px-4 py-3 pr-10 text-[12px] leading-normal text-white"
+        className="w-full bg-transparent text-[12.5px] text-white outline-0"
         type="text"
         placeholder={t('Search conversations...') || ''}
         value={searchTerm}
@@ -30,7 +43,7 @@ export const Search: FC<Props> = ({ searchTerm, onSearch }) => {
 
       {searchTerm && (
         <IconX
-          className="absolute right-4 cursor-pointer text-neutral-300 hover:text-neutral-400"
+          className="cursor-pointer text-neutral-300 hover:text-neutral-400"
           size={18}
           onClick={clearSearch}
         />

--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   IconFolderPlus,
   IconMessagesOff,
   IconPlus,
+  IconSearch,
 } from '@tabler/icons-react';
 import { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'next-i18next';
@@ -63,6 +64,7 @@ export const Sidebar: FC<Props> = ({
 }) => {
   const { t } = useTranslation('sidebar');
   const [searchTerm, setSearchTerm] = useState<string>('');
+  const [isSearchPage, setIsSearchPage] = useState<boolean>(false);
   const [filteredConversations, setFilteredConversations] =
     useState<Conversation[]>(conversations);
 
@@ -120,34 +122,45 @@ export const Sidebar: FC<Props> = ({
     <aside
       className={`fixed top-0 bottom-0 z-50 flex h-full w-[260px] flex-none flex-col space-y-2 bg-[#202123] p-2 transition-all sm:relative sm:top-0`}
     >
-      <header className="flex items-center">
-        <button
-          className="flex w-[190px] flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 p-3 text-[12px] leading-normal text-white transition-colors duration-200 select-none hover:bg-gray-500/10"
-          onClick={() => {
-            onNewConversation();
-            setSearchTerm('');
-          }}
-        >
-          <IconPlus size={18} />
-          {t('New chat')}
-        </button>
+      {!isSearchPage ? (
+        <header className="flex items-center">
+          <button
+            className="flex w-[140px] flex-shrink-0 cursor-pointer select-none items-center gap-3 rounded-md border border-white/20 p-3 text-[12px] leading-normal text-white transition-colors duration-200 hover:bg-gray-500/10"
+            onClick={() => {
+              onNewConversation();
+              setSearchTerm('');
+            }}
+          >
+            <IconPlus size={18} />
+            {t('New chat')}
+          </button>
 
-        <button
-          className="ml-2 flex flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 p-3 text-[12px] leading-normal text-white transition-colors duration-200 hover:bg-gray-500/10"
-          onClick={() => onCreateFolder(t('New folder'))}
-        >
-          <IconFolderPlus size={18} />
-        </button>
+          <button
+            className="ml-2 flex flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 p-3 text-[12px] leading-normal text-white transition-colors duration-200 hover:bg-gray-500/10"
+            onClick={() => onCreateFolder(t('New folder'))}
+          >
+            <IconFolderPlus size={18} />
+          </button>
 
-        <IconArrowBarLeft
-          className="ml-1 hidden cursor-pointer p-1 text-neutral-300 hover:text-neutral-400 sm:flex"
-          size={32}
-          onClick={onToggleSidebar}
+          <button
+            className="ml-2 flex flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 p-3 text-[12px] leading-normal text-white transition-colors duration-200 hover:bg-gray-500/10"
+            onClick={() => setIsSearchPage(!isSearchPage)}
+          >
+            <IconSearch size={18} />
+          </button>
+
+          <IconArrowBarLeft
+            className="ml-1 hidden cursor-pointer p-1 text-neutral-300 hover:text-neutral-400 sm:flex"
+            size={32}
+            onClick={onToggleSidebar}
+          />
+        </header>
+      ) : (
+        <Search
+          searchTerm={searchTerm}
+          onSearch={setSearchTerm}
+          onCloseSearch={() => setIsSearchPage(!isSearchPage)}
         />
-      </header>
-
-      {conversations.length > 1 && (
-        <Search searchTerm={searchTerm} onSearch={setSearchTerm} />
       )}
 
       <div className="flex-grow overflow-auto">
@@ -172,7 +185,7 @@ export const Sidebar: FC<Props> = ({
 
         {conversations.length > 0 ? (
           <div
-            className="h-full pt-2"
+            className="h-full"
             onDrop={(e) => handleDrop(e)}
             onDragOver={allowDrop}
             onDragEnter={highlightDrop}
@@ -192,9 +205,11 @@ export const Sidebar: FC<Props> = ({
             />
           </div>
         ) : (
-          <div className="mt-8 text-white text-center opacity-50 select-none">
-            <IconMessagesOff className='mx-auto mb-3'/>
-            <span className='text-[12px] leading-normal'>{t('No conversations.')}</span>
+          <div className="mt-8 select-none text-center text-white opacity-50">
+            <IconMessagesOff className="mx-auto mb-3" />
+            <span className="text-[12px] leading-normal">
+              {t('No conversations.')}
+            </span>
           </div>
         )}
       </div>

--- a/components/Sidebar/SidebarButton.tsx
+++ b/components/Sidebar/SidebarButton.tsx
@@ -9,11 +9,11 @@ interface Props {
 export const SidebarButton: FC<Props> = ({ text, icon, onClick }) => {
   return (
     <button
-      className="flex w-full cursor-pointer items-center gap-3 rounded-md py-3 px-3 text-white text-[12px] leading-normal transition-colors duration-200 hover:bg-gray-500/10 select-none"
+      className="flex w-full cursor-pointer gap-3 rounded-md py-3 px-3 text-white text-[12.5px] transition-colors duration-200 hover:bg-gray-500/10 select-none"
       onClick={onClick}
     >
       <div>{icon}</div>
-      <div>{text}</div>
+      <span>{text}</span>
     </button>
   );
 };


### PR DESCRIPTION
### Description
This commit change home block (modal and system message), make search in one line and add spinner component from ChatGPT. It appears on page load, instead of "Please wait..."

### Screenshots
| Normal mode | Search mode |
| --------------- | -------------- |
| ![image](https://user-images.githubusercontent.com/44939683/227772623-ff0a7a32-91b5-443c-9f0b-9cde0cf54c28.png) | ![image](https://user-images.githubusercontent.com/44939683/227772638-9c326760-824b-45f8-9d92-87686ea6a341.png) |
