### PR TITLE
Fix unreadable dropdown menu text in dark mode

### DIFF
--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -17,7 +17,7 @@ export const ModelSelect: FC<Props> = ({ model, models, onModelChange }) => {
       </label>
       <div className="w-full rounded-lg border border-neutral-200 bg-transparent pr-2 text-neutral-900 dark:border-neutral-600 dark:text-white">
         <select
-          className="focus:shadow-outline w-full cursor-pointer appearance-none rounded-lg border border-neutral-500 p-3 text-neutral-900 dark:border-neutral-400 dark:bg-[#343541] dark:text-white"
+          className="w-full bg-transparent p-2 outline-0"
           placeholder={t('Select a model') || ''}
           value={model.id}
           onChange={(e) => {

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -15,9 +15,9 @@ export const ModelSelect: FC<Props> = ({ model, models, onModelChange }) => {
       <label className="mb-2 text-left text-neutral-700 dark:text-neutral-400">
         {t('Model')}
       </label>
-      <div className="w-full rounded-lg border border-neutral-200 pr-2 bg-transparent text-neutral-900 dark:border-neutral-600 dark:text-white">
+      <div className="w-full rounded-lg border border-neutral-200 bg-transparent pr-2 text-neutral-900 dark:border-neutral-600 dark:text-white">
         <select
-          className="bg-transparent w-full outline-0 p-2"
+          className="focus:shadow-outline w-full cursor-pointer appearance-none rounded-lg border border-neutral-500 p-3 text-neutral-900 dark:border-neutral-400 dark:bg-[#343541] dark:text-white"
           placeholder={t('Select a model') || ''}
           value={model.id}
           onChange={(e) => {
@@ -29,7 +29,11 @@ export const ModelSelect: FC<Props> = ({ model, models, onModelChange }) => {
           }}
         >
           {models.map((model) => (
-            <option key={model.id} value={model.id}>
+            <option
+              key={model.id}
+              value={model.id}
+              className="dark:bg-[#343541] dark:text-white"
+            >
               {model.name}
             </option>
           ))}


### PR DESCRIPTION
This pull request addresses the issue of the dropdown menu text being unreadable in dark mode. The changes include adding the appropriate dark mode styles for the dropdown menu and options.

![Screenshot (291)](https://user-images.githubusercontent.com/111579522/227786645-c9317527-1090-49dd-bab8-cdb161cc945e.png)
