### PR TITLE
fix: overlap between plus and prompt menu icon

### DIFF
--- a/components/Mobile/Navbar.tsx
+++ b/components/Mobile/Navbar.tsx
@@ -20,7 +20,7 @@ export const Navbar: FC<Props> = ({
       </div>
 
       <IconPlus
-        className="cursor-pointer hover:text-neutral-400"
+        className="cursor-pointer hover:text-neutral-400 mr-8"
         onClick={onNewConversation}
       />
     </nav>


### PR DESCRIPTION
Fixed the overlap between the plus icon (new conversation) and prompt menu icon

## Before
![overlap](https://user-images.githubusercontent.com/38078427/228002630-56978756-3b65-4b98-8ee7-90cc9bf25a17.png)
## After 
![overlap-resolved](https://user-images.githubusercontent.com/38078427/228002620-d9506c26-1bcf-4436-b8d4-cca11049ea3f.png)
