### PR TITLE
fix: prompt sidebar not showing on small devices

### DIFF
--- a/components/Promptbar/Promptbar.tsx
+++ b/components/Promptbar/Promptbar.tsx
@@ -96,7 +96,7 @@ export const Promptbar: FC<Props> = ({
 
   return (
     <div
-      className={`fixed top-0 bottom-0 z-50 flex h-full w-[260px] flex-none flex-col space-y-2 bg-[#202123] p-2 text-[14px] transition-all sm:relative sm:top-0`}
+      className={`fixed top-0 right-0 z-50 flex h-full w-[260px] flex-none flex-col space-y-2 bg-[#202123] p-2 text-[14px] transition-all sm:relative sm:top-0`}
     >
       <div className="flex items-center">
         <button


### PR DESCRIPTION
Fixed the issue with Prompt sidebar not showing on small devices

 ## Before
![overlap](https://user-images.githubusercontent.com/38078427/228007221-2788cc30-1611-4520-af19-ff002857be11.png)
## After
![overlap-resolved](https://user-images.githubusercontent.com/38078427/228007231-e9133d68-6c5a-49bc-8fd4-9673dd621df5.png)
