### PR TITLE
prettierignore to remove formatting from some folders

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+**/.next/**
+**/_next/**
+**/dist/**
+package-lock.json


### PR DESCRIPTION
When using yarn format it would format all the files including files in .next and some other folders. This file will stop it from doing so