### PR TITLE
use proxychains4 to access the OpenAI API in the command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ OPENAI_API_KEY=YOUR_KEY
 npm run dev
 ```
 
+> you can use `proxychain4` to help you access the official OpenAI API, if you have a proxy.
+
+```bash
+// First: install proxychains4
+apt-get install proxychain4 // in ubuntu
+// Second: set your proxy in the proxychains.conf
+// For example: if you are using ubuntu, in the /etc/proxychains.conf
+socks5 yourIp yourSocket
+// or
+http yourIP yourSocket
+
+// Run APP
+proxychains4 npm run dev
+``` 
+
 **5. Use It**
 
 You should be able to start chatting.


### PR DESCRIPTION
## background
- I don't have a OPENAI_API_HOST
- I set the proxy global, but it always complains that it can't connect the OpenAI API
- I use `proxychains npm run dev` command, but it often gives errors.
- After using `proxychains4 npm run dev`, I got it to work.

- 
![image](https://user-images.githubusercontent.com/101320682/228555668-f0e1f952-821f-49d1-a15f-abe1f28d75be.png)


## proxychains4
```
proxychains4 npm run dev
```