### PR TITLE
Improve API error handling for better debugging

### DIFF
--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -34,13 +34,14 @@ export const OpenAIStream = async (
     }),
   });
 
-  if (res.status !== 200) {
-    const statusText = res.statusText;
-    throw new Error(`OpenAI API returned an error: ${statusText}`);
-  }
-
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
+
+  if (res.status !== 200) {
+    const statusText = res.statusText;
+    const result = await res.body?.getReader().read();
+    throw new Error(`OpenAI API returned an error: ${decoder.decode(result?.value) || statusText}`);
+  }
 
   const stream = new ReadableStream({
     async start(controller) {


### PR DESCRIPTION
Previously, developers were only notified of a 'Bad Request' error when receiving a 400 response. 

![image](https://user-images.githubusercontent.com/360426/228623324-31e9285c-6fdc-4f71-9379-3b35f0e7dd8e.png)

However, with the new code, developers can receive detailed information about what happened during the API call. This allows for better debugging and error handling.

![image](https://user-images.githubusercontent.com/360426/228623723-96ff1c56-17e0-4cdb-96c0-03e5b57fe63c.png)
