### PR TITLE
Allow specifying OpenAI-Organization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Create a .env.local file in the root of the repo with your OpenAI API Key:
 OPENAI_API_KEY=YOUR_KEY
 ```
 
-> you can set `OPENAI_API_HOST` where access to the official OpenAI host is restricted or unavailable, allowing users to configure an alternative host for their specific needs.
+> You can set `OPENAI_API_HOST` where access to the official OpenAI host is restricted or unavailable, allowing users to configure an alternative host for their specific needs.
+
+> Additionally, if you have multiple OpenAI Organizations, you can set `OPENAI_ORGANIZATION` to specify one.
 
 **4. Run App**
 

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -15,6 +15,9 @@ const handler = async (req: Request): Promise<Response> => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,
+        ...(process.env.OPENAI_ORGANIZATION && {
+          'OpenAI-Organization': process.env.OPENAI_ORGANIZATION,
+        })
       },
     });
 

--- a/types/env.ts
+++ b/types/env.ts
@@ -1,4 +1,5 @@
 export interface ProcessEnv {
   OPENAI_API_KEY: string;
   OPENAI_API_HOST?: string;
+  OPENAI_ORGANIZATION?: string;
 }

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -17,6 +17,9 @@ export const OpenAIStream = async (
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,
+      ...(process.env.OPENAI_ORGANIZATION && {
+        'OpenAI-Organization': process.env.OPENAI_ORGANIZATION,
+      })
     },
     method: 'POST',
     body: JSON.stringify({


### PR DESCRIPTION
See https://platform.openai.com/docs/api-reference/introduction

> For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API request. Usage from these API requests will count against the specified organization's subscription quota.

We have this deployed and it's working correctly.