### PR TITLE
Feature: add link to openai account usage

### DIFF
--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -48,6 +48,11 @@ export const ModelSelect: FC<Props> = ({
           ))}
         </select>
       </div>
+      <div className="w-full">
+        <a href="https://platform.openai.com/account/usage" target="_blank">
+          {t('View Account Usage')}
+        </a>
+      </div>
     </div>
   );
 };

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -1,5 +1,6 @@
 import { OpenAIModel, OpenAIModelID } from '@/types/openai';
 import { useTranslation } from 'next-i18next';
+import { IconExternalLink } from '@tabler/icons-react';
 import { FC } from 'react';
 
 interface Props {

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -48,8 +48,9 @@ export const ModelSelect: FC<Props> = ({
           ))}
         </select>
       </div>
-      <div className="w-full">
-        <a href="https://platform.openai.com/account/usage" target="_blank">
+      <div className="w-full mt-3 text-left text-neutral-700 dark:text-neutral-400 flex items-center">
+        <a href="https://platform.openai.com/account/usage" target="_blank" className="flex items-center">
+          <IconExternalLink size={18} className={"inline mr-1"} />
           {t('View Account Usage')}
         </a>
       </div>


### PR DESCRIPTION
* adds an external link that opens in a new tab to the OpenAI account usage page
* this is useful to see how many requests have been spent and the cost
* this becomes more useful when there is a choice of models

<img width="817" alt="Screenshot 2023-03-30 at 9 33 25 PM" src="https://user-images.githubusercontent.com/89982117/229000616-81cd0ee0-d9c1-4e92-9272-ef3547b6be2b.png">
