### PR TITLE
feat: Adds a loading spinner that replaces send icon while result is generated

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -286,7 +286,11 @@ export const ChatInput: FC<Props> = ({
             className="absolute right-2 top-2 rounded-sm p-1 text-neutral-800 opacity-60 hover:bg-neutral-200 hover:text-neutral-900 dark:bg-opacity-50 dark:text-neutral-100 dark:hover:text-neutral-200"
             onClick={handleSend}
           >
-            <IconSend size={18} />
+            {messageIsStreaming ? (
+              <div className="h-4 w-4 animate-spin rounded-full border-t-2 border-neutral-800 opacity-60 dark:border-neutral-100"></div>
+            ) : (
+              <IconSend size={18} />
+            )}
           </button>
 
           {showPromptList && prompts.length > 0 && (


### PR DESCRIPTION
Adds a loading spinner that replaces send icon while result is generated

Replaces icon when you hit send, goes away when a result is generated or an error happens

![image](https://user-images.githubusercontent.com/490005/229156749-fd4e3cfc-835b-4ddf-b5ea-20f817aa7c0c.png)
![image](https://user-images.githubusercontent.com/490005/229156782-3edcb933-62ab-40e0-b0ed-6f4efbfbbb57.png)
