### PR TITLE
doc: update README.md for using Azure OpenAI Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ When deploying the application, the following environment variables can be set:
 If you do not provide an OpenAI API key with `OPENAI_API_KEY`, users will have to provide their own key.
 If you don't have an OpenAI API key, you can get one [here](https://platform.openai.com/account/api-keys).
 
+### Microsoft Azure Endpoints
+
+Please consider using Azure OpenAI service proxy to convert OpenAI official API request to Azure OpenAI API request. For example, [stulzq/azure-openai-proxy](https://github.com/stulzq/azure-openai-proxy) or [diemus/azure-openai-proxy](https://github.com/diemus/azure-openai-proxy).
+
 ## Contact
 
 If you have any questions, feel free to reach out to me on [Twitter](https://twitter.com/mckaywrigley).


### PR DESCRIPTION
I made some local changes to support Azure OpenAI Service and found that a significant amount of code needs modification. This would greatly increase the code's complexity, and there are still some difficult-to-solve problems.

First, let's discuss the changes necessary to support Azure OpenAI Service:

1. Different API route for `/chat/completion`: `/openai/deployments/{deploymentID}/chat/completions?api-version=2023-03-15-preview`
2. Azure OpenAI Service does not have `/v1/models` API, so it needs to be replaced with the `/openai/deployments?api-version=2023-03-15-preview` API
3. There is an Auth Key mismatch. `headers` must include the `api-key`
4. [Some model names are different.](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/chatgpt?pivots=programming-language-chat-completions#model-versioning)

The existing problems are:

1. The current code cannot stop generation, which requires modifications for support. This might be due to the differences between OpenAI and Azure OpenAI results, with [but eventsource-parser did not make any special treatment for Azure OpenAI.](https://github.com/rexxars/eventsource-parser/blob/main/src/parse.ts#L122)
      - Azure OpenAI API output is missing a `\n` compared to OpenAI API output:
          <img width="960" alt="image" src="https://user-images.githubusercontent.com/38807139/229241817-58c20c8c-f6d2-40fe-89f2-6c86d9a456b2.png">
          <img width="972" alt="image" src="https://user-images.githubusercontent.com/38807139/229242034-85f6ef1c-0530-4d88-bb1d-c967fabf4995.png">
    a. [To get the /chat/completions to stop generating, I added the following code to utils/server/index.ts](https://github.com/mckaywrigley/chatbot-ui/issues/243#issuecomment-1491533867)
    b. [After switching to Azure, the conversation cannot be automatically stopped](https://github.com/Chanzhaoyu/chatgpt-web/issues/831)
2. Streaming output has issues; it's not possible to output word by word for an unknown reason.

In conclusion, I recommend using Azure OpenAI Service proxy to convert official OpenAI API requests into Azure OpenAI API requests. This approach is more elegant than modifying the code repository, as it avoids extensive code changes and doesn't require adding additional environment variables (which would be inconvenient for users).