### PR TITLE
fix: label layout shift

### DIFF
--- a/components/Chat/ChatLoader.tsx
+++ b/components/Chat/ChatLoader.tsx
@@ -9,8 +9,8 @@ export const ChatLoader: FC<Props> = () => {
       className="group border-b border-black/10 bg-gray-50 text-gray-800 dark:border-gray-900/50 dark:bg-[#444654] dark:text-gray-100"
       style={{ overflowWrap: 'anywhere' }}
     >
-      <div className="m-auto flex gap-4 p-4 text-base md:max-w-2xl md:gap-6 md:py-6 lg:max-w-2xl lg:px-0 xl:max-w-3xl">
-        <div className="min-w-[40px] font-bold">AI:</div>
+      <div className="flex gap-4 p-4 m-auto text-base md:max-w-2xl md:gap-6 md:py-6 lg:max-w-2xl lg:px-0 xl:max-w-3xl">
+        <div className="min-w-[40px] text-right font-bold">AI:</div>
         <IconDots className="animate-pulse" />
       </div>
     </div>


### PR DESCRIPTION
stops layout shift on the "AI:" label when it's loading