### PR TITLE
fix: prompts list height

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -289,7 +289,7 @@ export const ChatInput: FC<Props> = ({
             <IconSend size={18} />
           </button>
 
-          {showPromptList && prompts.length > 0 && (
+          {showPromptList && filteredPrompts.length > 0 && (
             <div className="absolute bottom-12 w-full">
               <PromptList
                 activePromptIndex={activePromptIndex}

--- a/components/Chat/SystemPrompt.tsx
+++ b/components/Chat/SystemPrompt.tsx
@@ -215,7 +215,7 @@ export const SystemPrompt: FC<Props> = ({
         onKeyDown={handleKeyDown}
       />
 
-      {showPromptList && prompts.length > 0 && (
+      {showPromptList && filteredPrompts.length > 0 && (
         <div>
           <PromptList
             activePromptIndex={activePromptIndex}


### PR DESCRIPTION
The prompts list view should be hidden when there are no optional items.
  
Before:

https://user-images.githubusercontent.com/1320925/229265751-29c49eba-6471-4338-8682-bd03db6d7a5e.mp4
  
After:

https://user-images.githubusercontent.com/1320925/229265742-40e93e28-e80c-48bd-b298-52a581932005.mp4



