### PR TITLE
Fix: arrow down icon color

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -318,7 +318,7 @@ export const Chat: FC<Props> = memo(
         {showScrollDownButton && (
           <div className="absolute bottom-0 right-0 mb-4 mr-4 pb-20">
             <button
-              className="flex h-7 w-7 items-center justify-center rounded-full bg-neutral-200 text-gray-700 shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700"
+              className="flex h-7 w-7 items-center justify-center rounded-full bg-neutral-200 shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700"
               onClick={handleScrollDown}
             >
               <IconArrowDown size={18} />


### PR DESCRIPTION
## Description
Remove the `text-gray-700` styling that appears to have been a typo introduced in #311 
https://github.com/mckaywrigley/chatbot-ui/pull/311/files#diff-1e0a9028c7e648dfcce33253662217a1ef92ab0d8f15d4685d7ab7c37dd73fcfR321

**Before**
![image](https://user-images.githubusercontent.com/4507317/229277485-50155fc8-5911-45d7-ba8c-6cd730313dea.png)
**After**
![image](https://user-images.githubusercontent.com/4507317/229277489-2e6c3166-28a8-4680-910b-b9a01203ce6b.png)
