### PR TITLE
fix for openai token limit error

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -35,7 +35,7 @@ const handler = async (req: Request): Promise<Response> => {
       const message = messages[i];
       const tokens = encoding.encode(message.content);
 
-      if (tokenCount + tokens.length > model.tokenLimit) {
+      if (tokenCount + tokens.length + 1000 > model.tokenLimit) {
         break;
       }
       tokenCount += tokens.length;


### PR DESCRIPTION
This is a little fix for cases when token count for prompt and system messages are higher than `model's token limit - 1000` (7192 for gpt4-8k model in my case and 1000 tokens are reserved for openai api response using `max_tokens` parameter)

So now if token count goes above 7192 (+1000) this loop stops adding next message to the `messagesToSend ` array
```typescript
    for (let i = messages.length - 1; i >= 0; i--) {
      const message = messages[i];
      const tokens = encoding.encode(message.content);

      // 1000 tokens reserved for completion
      if (tokenCount + tokens.length + 1000 > model.tokenLimit) {
        break;
      }
      tokenCount += tokens.length;
      messagesToSend = [message, ...messagesToSend];
    }
```