### PR TITLE
remove dupe main (accessibility)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,10 +8,10 @@ const inter = Inter({ subsets: ['latin'] });
 
 function App({ Component, pageProps }: AppProps<{}>) {
   return (
-    <main className={inter.className}>
+    <div className={inter.className}>
       <Toaster />
       <Component {...pageProps} />
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
Site should only have one main.

BEFORE:
![dupeMain](https://user-images.githubusercontent.com/5056972/229333771-77b5b109-f346-4be7-8add-3c93cbb69de6.png)


AFTER:
![nodupeMain](https://user-images.githubusercontent.com/5056972/229333774-6d3cc675-d2d2-49c9-afb4-15e8ccb1f60c.png)

fixes: #354 