### PR TITLE
remove unused chatbar/promptbar toggle code

### DIFF
--- a/components/Chatbar/Chatbar.tsx
+++ b/components/Chatbar/Chatbar.tsx
@@ -3,7 +3,6 @@ import { KeyValuePair } from '@/types/data';
 import { SupportedExportFormats } from '@/types/export';
 import { Folder } from '@/types/folder';
 import {
-  IconArrowBarLeft,
   IconFolderPlus,
   IconMessagesOff,
   IconPlus,
@@ -29,7 +28,6 @@ interface Props {
   onToggleLightMode: (mode: 'light' | 'dark') => void;
   onSelectConversation: (conversation: Conversation) => void;
   onDeleteConversation: (conversation: Conversation) => void;
-  onToggleSidebar: () => void;
   onUpdateConversation: (
     conversation: Conversation,
     data: KeyValuePair,
@@ -54,7 +52,6 @@ export const Chatbar: FC<Props> = ({
   onToggleLightMode,
   onSelectConversation,
   onDeleteConversation,
-  onToggleSidebar,
   onUpdateConversation,
   onApiKeyChange,
   onClearConversations,
@@ -138,12 +135,6 @@ export const Chatbar: FC<Props> = ({
         >
           <IconFolderPlus size={18} />
         </button>
-
-        <IconArrowBarLeft
-          className="ml-1 hidden cursor-pointer p-1 text-neutral-300 hover:text-neutral-400 sm:flex"
-          size={32}
-          onClick={onToggleSidebar}
-        />
       </div>
 
       {conversations.length > 1 && (

--- a/components/Promptbar/Promptbar.tsx
+++ b/components/Promptbar/Promptbar.tsx
@@ -1,7 +1,6 @@
 import { Folder } from '@/types/folder';
 import { Prompt } from '@/types/prompt';
 import {
-  IconArrowBarRight,
   IconFolderPlus,
   IconMistOff,
   IconPlus,
@@ -19,7 +18,6 @@ interface Props {
   onCreateFolder: (name: string) => void;
   onDeleteFolder: (folderId: string) => void;
   onUpdateFolder: (folderId: string, name: string) => void;
-  onToggleSidebar: () => void;
   onCreatePrompt: () => void;
   onUpdatePrompt: (prompt: Prompt) => void;
   onDeletePrompt: (prompt: Prompt) => void;
@@ -34,7 +32,6 @@ export const Promptbar: FC<Props> = ({
   onCreatePrompt,
   onUpdatePrompt,
   onDeletePrompt,
-  onToggleSidebar,
 }) => {
   const { t } = useTranslation('promptbar');
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -117,12 +114,6 @@ export const Promptbar: FC<Props> = ({
         >
           <IconFolderPlus size={16} />
         </button>
-
-        <IconArrowBarRight
-          className="hidden p-1 ml-1 cursor-pointer text-neutral-300 hover:text-neutral-400 sm:flex"
-          size={32}
-          onClick={onToggleSidebar}
-        />
       </div>
 
       {prompts.length > 1 && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -662,7 +662,6 @@ const Home: React.FC<HomeProps> = ({
                   onNewConversation={handleNewConversation}
                   onSelectConversation={handleSelectConversation}
                   onDeleteConversation={handleDeleteConversation}
-                  onToggleSidebar={handleToggleChatbar}
                   onUpdateConversation={handleUpdateConversation}
                   onApiKeyChange={handleApiKeyChange}
                   onClearConversations={handleClearConversations}
@@ -713,7 +712,6 @@ const Home: React.FC<HomeProps> = ({
                 <Promptbar
                   prompts={prompts}
                   folders={folders.filter((folder) => folder.type === 'prompt')}
-                  onToggleSidebar={handleTogglePromptbar}
                   onCreatePrompt={handleCreatePrompt}
                   onUpdatePrompt={handleUpdatePrompt}
                   onDeletePrompt={handleDeletePrompt}


### PR DESCRIPTION
This code is never called, (perhaps it is an earlier remnant of how to chatbar & promptbar were originally toggled)

(To be clear - the chatbar and promptbar still remain toggleable through buttons that are in place in index.tsx, here https://github.com/mckaywrigley/chatbot-ui/blob/main/pages/index.tsx#L675-L687 and 
https://github.com/mckaywrigley/chatbot-ui/blob/main/pages/index.tsx#L726-L738)

