### PR TITLE
tokenLimit can now be closer to real model limit.

### DIFF
--- a/types/openai.ts
+++ b/types/openai.ts
@@ -18,12 +18,12 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     id: OpenAIModelID.GPT_3_5,
     name: 'GPT-3.5',
     maxLength: 12000,
-    tokenLimit: 3000,
+    tokenLimit: 4000,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,
     name: 'GPT-4',
     maxLength: 24000,
-    tokenLimit: 6000,
+    tokenLimit: 8000,
   },
 };


### PR DESCRIPTION
After the changes in #350 , the output tokens don't need to be subtracted from `tokenLimit` anymore.
Note that we still can't use the exact model limits, we need some slack to take into account the tokens spent in the messsage-based-formatting (see section 6 of [this notebook from OpenAI](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)).