### PR TITLE
Fix 416 copy button on code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ When deploying the application, the following environment variables can be set:
 | --------------------- | ------------------------------ | ------------------------------------------------------- |
 | OPENAI_API_KEY        |                                | The default API key used for authentication with OpenAI |
 | DEFAULT_MODEL         | `gpt-3.5-turbo`                | The default model to use on new conversations           |
-| DEFAULT_SYSTEM_PROMPT | [see here](utils/app/const.ts) | The defaut system prompt to use on new conversations    |
+| DEFAULT_SYSTEM_PROMPT | [see here](utils/app/const.ts) | The default system prompt to use on new conversations   |
+| GOOGLE_API_KEY        |                                | See [Custom Search JSON API documentation][GCSE]        |
+| GOOGLE_CSE_ID         |                                | See [Custom Search JSON API documentation][GCSE]        |
 
 If you do not provide an OpenAI API key with `OPENAI_API_KEY`, users will have to provide their own key.
 If you don't have an OpenAI API key, you can get one [here](https://platform.openai.com/account/api-keys).
@@ -124,3 +126,5 @@ If you don't have an OpenAI API key, you can get one [here](https://platform.ope
 ## Contact
 
 If you have any questions, feel free to reach out to me on [Twitter](https://twitter.com/mckaywrigley).
+
+[GCSE]: https://developers.google.com/custom-search/v1/overview

--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -1,5 +1,11 @@
 import { Message } from '@/types/chat';
-import { IconCheck, IconCopy, IconEdit, IconUser, IconRobot } from '@tabler/icons-react';
+import {
+  IconCheck,
+  IconCopy,
+  IconEdit,
+  IconUser,
+  IconRobot,
+} from '@tabler/icons-react';
 import { useTranslation } from 'next-i18next';
 import { FC, memo, useEffect, useRef, useState } from 'react';
 import rehypeMathjax from 'rehype-mathjax';
@@ -81,7 +87,11 @@ export const ChatMessage: FC<Props> = memo(
       >
         <div className="relative m-auto flex gap-4 p-4 text-base md:max-w-2xl md:gap-6 md:py-6 lg:max-w-2xl lg:px-0 xl:max-w-3xl">
           <div className="min-w-[40px] text-right font-bold">
-            {message.role === 'assistant' ? <IconRobot size={30}/> : <IconUser size={30}/>}
+            {message.role === 'assistant' ? (
+              <IconRobot size={30} />
+            ) : (
+              <IconUser size={30} />
+            )}
           </div>
 
           <div className="prose mt-[-2px] w-full dark:prose-invert">
@@ -136,7 +146,7 @@ export const ChatMessage: FC<Props> = memo(
                   <button
                     className={`absolute translate-x-[1000px] text-gray-500 hover:text-gray-700 focus:translate-x-0 group-hover:translate-x-0 dark:text-gray-400 dark:hover:text-gray-300 ${
                       window.innerWidth < 640
-                        ? 'right-3 bottom-1'
+                        ? 'bottom-1 right-3'
                         : 'right-0 top-[26px]'
                     }
                     `}
@@ -151,7 +161,7 @@ export const ChatMessage: FC<Props> = memo(
                 <div
                   className={`absolute ${
                     window.innerWidth < 640
-                      ? 'right-3 bottom-1'
+                      ? 'bottom-1 right-3'
                       : 'right-0 top-[26px] m-0'
                   }`}
                 >
@@ -178,10 +188,10 @@ export const ChatMessage: FC<Props> = memo(
                     code({ node, inline, className, children, ...props }) {
                       const match = /language-(\w+)/.exec(className || '');
 
-                      return !inline && match ? (
+                      return !inline ? (
                         <CodeBlock
                           key={Math.random()}
-                          language={match[1]}
+                          language={(match && match[1]) || ''}
                           value={String(children).replace(/\n$/, '')}
                           {...props}
                         />
@@ -193,21 +203,21 @@ export const ChatMessage: FC<Props> = memo(
                     },
                     table({ children }) {
                       return (
-                        <table className="border-collapse border border-black py-1 px-3 dark:border-white">
+                        <table className="border-collapse border border-black px-3 py-1 dark:border-white">
                           {children}
                         </table>
                       );
                     },
                     th({ children }) {
                       return (
-                        <th className="break-words border border-black bg-gray-500 py-1 px-3 text-white dark:border-white">
+                        <th className="break-words border border-black bg-gray-500 px-3 py-1 text-white dark:border-white">
                           {children}
                         </th>
                       );
                     },
                     td({ children }) {
                       return (
-                        <td className="break-words border border-black py-1 px-3 dark:border-white">
+                        <td className="break-words border border-black px-3 py-1 dark:border-white">
                           {children}
                         </td>
                       );


### PR DESCRIPTION
As reported on #416, the _Copy code_ button does not always shows up on some code blocks, specifically when the content language is not recognized.

## Before fix

![image](https://user-images.githubusercontent.com/42300/229939280-32204713-e5a4-4ffa-830b-835d4996ec57.png)

## After fix

![image](https://user-images.githubusercontent.com/42300/229939374-e342ade8-c90f-46df-9ae9-03f256b7f9fe.png)


Fixes #416 

