### PR TITLE
Add GPT_4_32K

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -17,7 +17,7 @@ const handler = async (req: Request): Promise<Response> => {
         Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,
         ...(process.env.OPENAI_ORGANIZATION && {
           'OpenAI-Organization': process.env.OPENAI_ORGANIZATION,
-        })
+        }),
       },
     });
 
@@ -39,17 +39,15 @@ const handler = async (req: Request): Promise<Response> => {
 
     const models: OpenAIModel[] = json.data
       .map((model: any) => {
-        for (const [key, value] of Object.entries(OpenAIModelID)) {
-          if (value === model.id) {
-            return {
-              id: model.id,
-              name: OpenAIModels[value].name,
-            };
-          }
+        const modelId: OpenAIModelID = model.id;
+        if (Object.values(OpenAIModelID).includes(modelId)) {
+          return {
+            id: model.id,
+            name: OpenAIModels[modelId].name,
+          };
         }
       })
       .filter(Boolean);
-
     return new Response(JSON.stringify(models), { status: 200 });
   } catch (error) {
     console.error(error);

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -8,6 +8,7 @@ export interface OpenAIModel {
 export enum OpenAIModelID {
   GPT_3_5 = 'gpt-3.5-turbo',
   GPT_4 = 'gpt-4',
+  GPT_4_32K = 'gpt-4-32k',
 }
 
 // in case the `DEFAULT_MODEL` environment variable is not set or set to an unsupported model
@@ -25,5 +26,11 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     name: 'GPT-4',
     maxLength: 24000,
     tokenLimit: 8000,
+  },
+  [OpenAIModelID.GPT_4_32K]: {
+    id: OpenAIModelID.GPT_4_32K,
+    name: 'GPT-4-32K',
+    maxLength: 32000,
+    tokenLimit: 32000,
   },
 };


### PR DESCRIPTION
Minor refactor, and adding GPT_4_32K to the list of available models. 

`models.ts` checks which models the user's API key has access to. Since most users don't have access to GPT_4_32K, this change will not affect the large majority (only those with early access).