### PR TITLE
Fix for DEFAULT_SYSTEM_PROMPT

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,6 @@
 # Chatbot UI
 DEFAULT_MODEL=gpt-3.5-turbo
-DEFAULT_SYSTEM_PROMPT=You are ChatGPT, a large language model trained by OpenAI. Follow the user's instructions carefully. Respond using markdown.
+NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT=You are ChatGPT, a large language model trained by OpenAI. Follow the user's instructions carefully. Respond using markdown.
 OPENAI_API_KEY=YOUR_KEY
 
 # Google

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ When deploying the application, the following environment variables can be set:
 | AZURE_DEPLOYMENT_ID   |                                | Needed when Azure OpenAI, Ref [Azure OpenAI API](https://learn.microsoft.com/zh-cn/azure/cognitive-services/openai/reference#completions)                                |
 | OPENAI_ORGANIZATION   |                                | Your OpenAI organization ID                             |
 | DEFAULT_MODEL         | `gpt-3.5-turbo`                | The default model to use on new conversations, for Azure use `gpt-35-turbo` |
-| DEFAULT_SYSTEM_PROMPT | [see here](utils/app/const.ts) | The default system prompt to use on new conversations   |
+| NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT | [see here](utils/app/const.ts) | The default system prompt to use on new conversations   |
 | GOOGLE_API_KEY        |                                | See [Custom Search JSON API documentation][GCSE]        |
 | GOOGLE_CSE_ID         |                                | See [Custom Search JSON API documentation][GCSE]        |
 

--- a/utils/app/const.ts
+++ b/utils/app/const.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_SYSTEM_PROMPT =
-  process.env.DEFAULT_SYSTEM_PROMPT ||
+  process.env.NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT ||
   "You are ChatGPT, a large language model trained by OpenAI. Follow the user's instructions carefully. Respond using markdown.";
 
 export const OPENAI_API_HOST =


### PR DESCRIPTION
This is a pretty simple thing and it seems like this has already been talked about some with #388 and #399 but it seems like the PR was closed without actually merging any changes.

Issue:  
The DEFAULT_SYSTEM_PROMPT environment does not change the default system prompt in the ui
Reproduce: 
Attempt to change the default system prompt using the environment variable and it doesn't change.

Root Cause:  
Since the Next.js app is attempting to use the DEFAULT_SYSTEM_PROMPT environment variable on the client side it is unable to resolve the environment variables.  By default environment variables are only available within Node.js and not on the client side.

Fix:
I have fixed this in this PR by changing the environment variable to be prefixed with "NEXT_PUBLIC" which allows the client side access to this variable as described in the [documentation](https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser).

Alternative:
If we don't want to change the environment variable name we could refactor the code to pass the environment variable down another way (using getServerSideProps or getStaticProps for example). 

