### PR TITLE
Fix Google plugin issue

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -224,7 +224,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
           };
           homeDispatch({
             field: 'selectedConversation',
-            value: updateConversation,
+            value: updatedConversation,
           });
           saveConversation(updatedConversation);
           const updatedConversations: Conversation[] = conversations.map(


### PR DESCRIPTION
Closes #534, closes #528 

Fixes a typo that causes selectedConversation to become invalid.


