### PR TITLE
Pass correct variable to homeDispatch

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -224,7 +224,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
           };
           homeDispatch({
             field: 'selectedConversation',
-            value: updateConversation,
+            value: updatedConversation,
           });
           saveConversation(updatedConversation);
           const updatedConversations: Conversation[] = conversations.map(


### PR DESCRIPTION
Hey! I'm was evaluating ChatBotUI for inclusion on the Fractal Mosaic App Store (https://apps.fractalnetworks.co) and came across the following typo while testing the Google Search plugin functionality.

Is there a high level overview of how the Google Search plugin is supposed to work? I'm getting these responses now that the change in this PR is in:

```
I'm sorry, I cannot provide a response to this prompt. It appears to have been incorrectly formatted, as the sources and the prompt don't match.
```

and

```
... input subject is too broad.
```

Happy to try and get a fix in for the search functionality and getting a little direction on what its supposed to do could save me some time of spelunking through code.

Thanks