### PR TITLE
Fixed: site breaks if imported json invalid

### DIFF
--- a/utils/app/clean.ts
+++ b/utils/app/clean.ts
@@ -8,6 +8,7 @@ export const cleanSelectedConversation = (conversation: Conversation) => {
   // added system prompt for each conversation (3/21/23)
   // added folders (3/23/23)
   // added prompts (3/26/23)
+  // added messages (4/16/23)
 
   let updatedConversation = conversation;
 
@@ -41,6 +42,13 @@ export const cleanSelectedConversation = (conversation: Conversation) => {
     };
   }
 
+  if (!updatedConversation.messages) {
+    updatedConversation = {
+      ...updatedConversation,
+      messages: updatedConversation.messages || [],
+    };
+  }
+
   return updatedConversation;
 };
 
@@ -49,6 +57,7 @@ export const cleanConversationHistory = (history: any[]): Conversation[] => {
   // added system prompt for each conversation (3/21/23)
   // added folders (3/23/23)
   // added prompts (3/26/23)
+  // added messages (4/16/23)
 
   if (!Array.isArray(history)) {
     console.warn('history is not an array. Returning an empty array.');
@@ -71,6 +80,10 @@ export const cleanConversationHistory = (history: any[]): Conversation[] => {
 
       if (!conversation.folderId) {
         conversation.folderId = null;
+      }
+
+      if (!conversation.messages) {
+        conversation.messages = [];
       }
 
       acc.push(conversation);


### PR DESCRIPTION
If the users imports a json file that contains invalid data, the site will constanstly display an error message not letting the user delete the conversation caused that error.
Prevention for this already exists, however it seems that the "messages" property was forgotten.
This is especially import, as that error occurs when trying to import data, exported by ChatGPT.

Having added that to the clean.ts file, it now no longer gives any errors and allows the user to delete those invalid imported conversations right from the website UI and no longer needs to painfully modify raw json from the devtools.

Edit: Helps with #572