### PR TITLE
Added multi-line input option (also fixed theme setting not saved)

### DIFF
--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -43,7 +43,7 @@ export const ChatInput = ({
   const { t } = useTranslation('chat');
 
   const {
-    state: { selectedConversation, messageIsStreaming, prompts },
+    state: { selectedConversation, messageIsStreaming, prompts, lineMode },
 
     dispatch: homeDispatch,
   } = useContext(HomeContext);
@@ -157,7 +157,7 @@ export const ChatInput = ({
       } else {
         setActivePromptIndex(0);
       }
-    } else if (e.key === 'Enter' && !isTyping && !isMobile() && !e.shiftKey) {
+    } else if (e.key === 'Enter' && (lineMode === 'single' || (lineMode === 'multi' && e.ctrlKey)) && !isTyping && !isMobile() && !e.shiftKey) {
       e.preventDefault();
       handleSend();
     } else if (e.key === '/' && e.metaKey) {

--- a/components/Chatbar/components/ChatbarSettings.tsx
+++ b/components/Chatbar/components/ChatbarSettings.tsx
@@ -1,4 +1,4 @@
-import { IconFileExport, IconMoon, IconSun } from '@tabler/icons-react';
+import { IconFileExport, IconMoon, IconSun, IconTextWrap, IconTextWrapDisabled } from '@tabler/icons-react';
 import { useContext } from 'react';
 
 import { useTranslation } from 'next-i18next';
@@ -19,6 +19,7 @@ export const ChatbarSettings = () => {
     state: {
       apiKey,
       lightMode,
+      lineMode,
       serverSideApiKeyIsSet,
       serverSidePluginKeysSet,
       conversations,
@@ -49,16 +50,36 @@ export const ChatbarSettings = () => {
       />
 
       <SidebarButton
+        text={lineMode === 'multi' ? t('Single Line') : t('Multi Line')}
+        title={lineMode === 'multi' ? t('Send on Enter') : t('Send on Ctrl+Enter')}
+        icon={
+          lineMode === 'multi' ? <IconTextWrapDisabled size={18} /> : <IconTextWrap size={18} />
+        }
+        onClick={() => {
+          const newLineMode = lineMode === 'single' ? 'multi' : 'single'
+          localStorage.setItem('lineMode', newLineMode);
+
+          return homeDispatch({
+            field: 'lineMode',
+            value: newLineMode,
+          })
+        }}
+      />
+
+      <SidebarButton
         text={lightMode === 'light' ? t('Dark mode') : t('Light mode')}
         icon={
           lightMode === 'light' ? <IconMoon size={18} /> : <IconSun size={18} />
         }
-        onClick={() =>
-          homeDispatch({
+        onClick={() => {
+          const newTheme = lightMode === 'light' ? 'dark' : 'light'
+          localStorage.setItem('theme', newTheme);
+
+          return homeDispatch({
             field: 'lightMode',
-            value: lightMode === 'light' ? 'dark' : 'light',
+            value: newTheme,
           })
-        }
+        }}
       />
 
       {!serverSideApiKeyIsSet ? (

--- a/components/Sidebar/SidebarButton.tsx
+++ b/components/Sidebar/SidebarButton.tsx
@@ -6,9 +6,10 @@ interface Props {
   onClick: () => void;
 }
 
-export const SidebarButton: FC<Props> = ({ text, icon, onClick }) => {
+export const SidebarButton: FC<Props> = ({ text, title = '', icon, onClick }) => {
   return (
     <button
+      title={title}
       className="flex w-full cursor-pointer select-none items-center gap-3 rounded-md py-3 px-3 text-[14px] leading-3 text-white transition-colors duration-200 hover:bg-gray-500/10"
       onClick={onClick}
     >

--- a/components/Sidebar/SidebarButton.tsx
+++ b/components/Sidebar/SidebarButton.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 
 interface Props {
   text: string;
+  title?: string | null;
   icon: JSX.Element;
   onClick: () => void;
 }
@@ -9,7 +10,7 @@ interface Props {
 export const SidebarButton: FC<Props> = ({ text, title = '', icon, onClick }) => {
   return (
     <button
-      title={title}
+      title={title ?? ''}
       className="flex w-full cursor-pointer select-none items-center gap-3 rounded-md py-3 px-3 text-[14px] leading-3 text-white transition-colors duration-200 hover:bg-gray-500/10"
       onClick={onClick}
     >

--- a/pages/api/home/home.state.tsx
+++ b/pages/api/home/home.state.tsx
@@ -10,6 +10,7 @@ export interface HomeInitialState {
   pluginKeys: PluginKey[];
   loading: boolean;
   lightMode: 'light' | 'dark';
+  lineMode: 'single' | 'multi';
   messageIsStreaming: boolean;
   modelError: ErrorMessage | null;
   models: OpenAIModel[];
@@ -34,6 +35,7 @@ export const initialState: HomeInitialState = {
   loading: false,
   pluginKeys: [],
   lightMode: 'dark',
+  lineMode: 'single',
   messageIsStreaming: false,
   modelError: null,
   models: [],

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -255,6 +255,14 @@ const Home = ({
       dispatch({ field: 'lightMode', value: theme as 'dark' | 'light' });
     }
 
+    const lineMode = localStorage.getItem('lineMode');
+    if (lineMode) {
+      dispatch({ field: 'lineMode', value: lineMode as 'single' | 'multi' });
+    }
+    else {
+      dispatch({ field: 'lineMode', value: 'single' });
+    }
+
     const apiKey = localStorage.getItem('apiKey');
 
     if (serverSideApiKeyIsSet) {

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -259,9 +259,6 @@ const Home = ({
     if (lineMode) {
       dispatch({ field: 'lineMode', value: lineMode as 'single' | 'multi' });
     }
-    else {
-      dispatch({ field: 'lineMode', value: 'single' });
-    }
 
     const apiKey = localStorage.getItem('apiKey');
 


### PR DESCRIPTION
Implemented Feature Request #566.
By default, messages are sent using Enter.
In multi-line mode, messages are sent using Ctrl+Enter. Enter alone creates a newline.

In the process also added missing localStorage.setItem call for theme setting