### PR TITLE
Fix search box disappearing in Sidebar component

### DIFF
--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -78,13 +78,11 @@ const Sidebar = <T,>({
             <IconFolderPlus size={16} />
           </button>
         </div>
-        {items?.length > 0 && (
-          <Search
-            placeholder={t('Search prompts...') || ''}
-            searchTerm={searchTerm}
-            onSearch={handleSearchTerm}
-          />
-        )}
+        <Search
+          placeholder={t('Search prompts...') || ''}
+          searchTerm={searchTerm}
+          onSearch={handleSearchTerm}
+        />
 
         <div className="flex-grow overflow-auto">
           {items?.length > 0 && (


### PR DESCRIPTION
Enable the search box to be always visible in the Sidebar component, regardless of the number of items or conversations. Remove the conditional rendering based on items length to ensure users can search and see filtered outcomes without the search box disappearing.
