### PR TITLE
Fix message truncation when exceeding token budget

### DIFF
--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -8,6 +8,7 @@ import wasm from '../../node_modules/@dqbd/tiktoken/lite/tiktoken_bg.wasm?module
 
 import tiktokenModel from '@dqbd/tiktoken/encoders/cl100k_base.json';
 import { Tiktoken, init } from '@dqbd/tiktoken/lite/init';
+import { OpenAIModelID, OpenAIModels } from '@/types/openai';
 
 export const config = {
   runtime: 'edge',
@@ -16,6 +17,8 @@ export const config = {
 const handler = async (req: Request): Promise<Response> => {
   try {
     const { model, messages, key, prompt, temperature } = (await req.json()) as ChatBody;
+
+    const {tokenLimit, messageTokens} = OpenAIModels[model.id as OpenAIModelID];
 
     await init((imports) => WebAssembly.instantiate(wasm, imports));
     const encoding = new Tiktoken(
@@ -34,19 +37,28 @@ const handler = async (req: Request): Promise<Response> => {
       temperatureToUse = DEFAULT_TEMPERATURE;
     }
 
-    const prompt_tokens = encoding.encode(promptToSend);
+    let tokenCount = encoding.encode(promptToSend).length;
+    tokenCount += 3; // reply starts with <|start|>assistant<|end|>
+    tokenCount += 5; // We're off by 5. Unsure why.
 
-    let tokenCount = prompt_tokens.length;
     let messagesToSend: Message[] = [];
+
+    const maxReplyTokens = 1000; // hardcoded in utils/server
+    // I think we're calculating this correctly, but if we're off, it's by a
+    // _lot_ less than 100.
+    const safetyMargin = 100;
 
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i];
-      const tokens = encoding.encode(message.content);
 
-      if (tokenCount + tokens.length + 1000 > model.tokenLimit) {
+      const msgTokenCount = messageTokens +
+        encoding.encode(message.content).length +
+        encoding.encode(message.role).length;
+
+      if (tokenCount + msgTokenCount + maxReplyTokens + safetyMargin > tokenLimit) {
         break;
       }
-      tokenCount += tokens.length;
+      tokenCount += msgTokenCount;
       messagesToSend = [message, ...messagesToSend];
     }
 

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -5,6 +5,7 @@ export interface OpenAIModel {
   name: string;
   maxLength: number; // maximum length of a message
   tokenLimit: number;
+  messageTokens: number;
 }
 
 export enum OpenAIModelID {
@@ -22,24 +23,28 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     id: OpenAIModelID.GPT_3_5,
     name: 'GPT-3.5',
     maxLength: 12000,
-    tokenLimit: 4000,
+    tokenLimit: 4097,
+    messageTokens: 4,
   },
   [OpenAIModelID.GPT_3_5_AZ]: {
     id: OpenAIModelID.GPT_3_5_AZ,
     name: 'GPT-3.5',
     maxLength: 12000,
-    tokenLimit: 4000,
+    tokenLimit: 4097,
+    messageTokens: 4,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,
     name: 'GPT-4',
     maxLength: 24000,
-    tokenLimit: 8000,
+    tokenLimit: 8192,
+    messageTokens: 3,
   },
   [OpenAIModelID.GPT_4_32K]: {
     id: OpenAIModelID.GPT_4_32K,
     name: 'GPT-4-32K',
     maxLength: 96000,
     tokenLimit: 32000,
+    messageTokens: 3,
   },
 };


### PR DESCRIPTION
The code here attempts to drop earlier messages to reduce token count when the conversation gets too long, but it doesn't count right. This is much closer, at least... it agrees with OpenAI about one conversation being 4197 tokens and the truncation behaviour works correctly.