### PR TITLE
refactor(components): extend config with custom color

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -348,7 +348,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
   }, [messagesEndRef]);
 
   return (
-    <div className="relative flex-1 overflow-hidden bg-white dark:bg-[#343541]">
+    <div className="relative flex-1 overflow-hidden bg-white dark:bg-tuna">
       {!(apiKey || serverSideApiKeyIsSet) ? (
         <div className="mx-auto flex h-full w-[300px] flex-col justify-center space-y-6 sm:w-[600px]">
           <div className="text-center text-4xl font-bold text-black dark:text-white">
@@ -482,7 +482,7 @@ export const Chat = memo(({ stopConversationRef }: Props) => {
                 {loading && <ChatLoader />}
 
                 <div
-                  className="h-[162px] bg-white dark:bg-[#343541]"
+                  className="h-[162px] bg-white dark:bg-tuna"
                   ref={messagesEndRef}
                 />
               </>

--- a/components/Chat/ChatInput.tsx
+++ b/components/Chat/ChatInput.tsx
@@ -257,11 +257,11 @@ export const ChatInput = ({
   }, []);
 
   return (
-    <div className="absolute bottom-0 left-0 w-full border-transparent bg-gradient-to-b from-transparent via-white to-white pt-6 dark:border-white/20 dark:via-[#343541] dark:to-[#343541] md:pt-2">
+    <div className="absolute bottom-0 left-0 w-full border-transparent bg-gradient-to-b from-transparent via-white to-white pt-6 dark:border-white/20 dark:via-tuna dark:to-tuna md:pt-2">
       <div className="stretch mx-2 mt-4 flex flex-row gap-3 last:mb-2 md:mx-4 md:mt-[52px] md:last:mb-6 lg:mx-auto lg:max-w-3xl">
         {messageIsStreaming && (
           <button
-            className="absolute top-0 left-0 right-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white py-2 px-4 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-[#343541] dark:text-white md:mb-0 md:mt-2"
+            className="absolute top-0 left-0 right-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white py-2 px-4 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-tuna dark:text-white md:mb-0 md:mt-2"
             onClick={handleStopConversation}
           >
             <IconPlayerStop size={16} /> {t('Stop Generating')}
@@ -272,7 +272,7 @@ export const ChatInput = ({
           selectedConversation &&
           selectedConversation.messages.length > 0 && (
             <button
-              className="absolute top-0 left-0 right-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white py-2 px-4 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-[#343541] dark:text-white md:mb-0 md:mt-2"
+              className="absolute top-0 left-0 right-0 mx-auto mb-3 flex w-fit items-center gap-3 rounded border border-neutral-200 bg-white py-2 px-4 text-black hover:opacity-50 dark:border-neutral-600 dark:bg-tuna dark:text-white md:mb-0 md:mt-2"
               onClick={onRegenerate}
             >
               <IconRepeat size={16} /> {t('Regenerate response')}
@@ -289,7 +289,7 @@ export const ChatInput = ({
           </button>
 
           {showPluginSelect && (
-            <div className="absolute left-0 bottom-14 rounded bg-white dark:bg-[#343541]">
+            <div className="absolute left-0 bottom-14 rounded bg-white dark:bg-tuna">
               <PluginSelect
                 plugin={plugin}
                 onKeyDown={(e: any) => {

--- a/components/Chat/ChatMessage.tsx
+++ b/components/Chat/ChatMessage.tsx
@@ -129,7 +129,7 @@ export const ChatMessage: FC<Props> = memo(({ message, messageIndex, onEdit }) =
       className={`group md:px-4 ${
         message.role === 'assistant'
           ? 'border-b border-black/10 bg-gray-50 text-gray-800 dark:border-gray-900/50 dark:bg-[#444654] dark:text-gray-100'
-          : 'border-b border-black/10 bg-white text-gray-800 dark:border-gray-900/50 dark:bg-[#343541] dark:text-gray-100'
+          : 'border-b border-black/10 bg-white text-gray-800 dark:border-gray-900/50 dark:bg-tuna dark:text-gray-100'
       }`}
       style={{ overflowWrap: 'anywhere' }}
     >
@@ -149,7 +149,7 @@ export const ChatMessage: FC<Props> = memo(({ message, messageIndex, onEdit }) =
                 <div className="flex w-full flex-col">
                   <textarea
                     ref={textareaRef}
-                    className="w-full resize-none whitespace-pre-wrap border-none dark:bg-[#343541]"
+                    className="w-full resize-none whitespace-pre-wrap border-none dark:bg-tuna"
                     value={messageContent}
                     onChange={handleInputChange}
                     onKeyDown={handlePressEnter}

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -42,7 +42,7 @@ export const ModelSelect = () => {
             <option
               key={model.id}
               value={model.id}
-              className="dark:bg-[#343541] dark:text-white"
+              className="dark:bg-tuna dark:text-white"
             >
               {model.id === defaultModelId
                 ? `Default (${model.name})`

--- a/components/Chat/PluginSelect.tsx
+++ b/components/Chat/PluginSelect.tsx
@@ -82,7 +82,7 @@ export const PluginSelect: FC<Props> = ({
           <option
             key="chatgpt"
             value="chatgpt"
-            className="dark:bg-[#343541] dark:text-white"
+            className="dark:bg-tuna dark:text-white"
           >
             ChatGPT
           </option>
@@ -91,7 +91,7 @@ export const PluginSelect: FC<Props> = ({
             <option
               key={plugin.id}
               value={plugin.id}
-              className="dark:bg-[#343541] dark:text-white"
+              className="dark:bg-tuna dark:text-white"
             >
               {plugin.name}
             </option>

--- a/components/Chat/PromptList.tsx
+++ b/components/Chat/PromptList.tsx
@@ -20,7 +20,7 @@ export const PromptList: FC<Props> = ({
   return (
     <ul
       ref={promptListRef}
-      className="z-10 max-h-52 w-full overflow-scroll rounded border border-black/10 bg-white shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:border-neutral-500 dark:bg-[#343541] dark:text-white dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]"
+      className="z-10 max-h-52 w-full overflow-scroll rounded border border-black/10 bg-white shadow-[0_0_10px_rgba(0,0,0,0.10)] dark:border-neutral-500 dark:bg-tuna dark:text-white dark:shadow-[0_0_15px_rgba(0,0,0,0.10)]"
     >
       {prompts.map((prompt, index) => (
         <li

--- a/components/Chatbar/components/Conversation.tsx
+++ b/components/Chatbar/components/Conversation.tsx
@@ -103,7 +103,7 @@ export const ConversationComponent = ({ conversation }: Props) => {
   return (
     <div className="relative flex items-center">
       {isRenaming && selectedConversation?.id === conversation.id ? (
-        <div className="flex w-full items-center gap-3 rounded-lg bg-[#343541]/90 p-3">
+        <div className="flex w-full items-center gap-3 rounded-lg bg-tuna/90 p-3">
           <IconMessage size={18} />
           <input
             className="mr-12 flex-1 overflow-hidden overflow-ellipsis border-neutral-400 bg-transparent text-left text-[12.5px] leading-3 text-white outline-none focus:border-neutral-100"
@@ -116,11 +116,11 @@ export const ConversationComponent = ({ conversation }: Props) => {
         </div>
       ) : (
         <button
-          className={`flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-[#343541]/90 ${
+          className={`flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-tuna/90 ${
             messageIsStreaming ? 'disabled:cursor-not-allowed' : ''
           } ${
             selectedConversation?.id === conversation.id
-              ? 'bg-[#343541]/90'
+              ? 'bg-tuna/90'
               : ''
           }`}
           onClick={() => handleSelectConversation(conversation)}

--- a/components/Folder/Folder.tsx
+++ b/components/Folder/Folder.tsx
@@ -95,7 +95,7 @@ const Folder = ({
     <>
       <div className="relative flex items-center">
         {isRenaming ? (
-          <div className="flex w-full items-center gap-3 bg-[#343541]/90 p-3">
+          <div className="flex w-full items-center gap-3 bg-tuna/90 p-3">
             {isOpen ? (
               <IconCaretDown size={18} />
             ) : (
@@ -112,7 +112,7 @@ const Folder = ({
           </div>
         ) : (
           <button
-            className={`flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-[#343541]/90`}
+            className={`flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-tuna/90`}
             onClick={() => setIsOpen(!isOpen)}
             onDrop={(e) => dropHandler(e)}
             onDragOver={allowDrop}

--- a/components/Promptbar/components/Prompt.tsx
+++ b/components/Promptbar/components/Prompt.tsx
@@ -78,7 +78,7 @@ export const PromptComponent = ({ prompt }: Props) => {
   return (
     <div className="relative flex items-center">
       <button
-        className="flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-[#343541]/90"
+        className="flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-sm transition-colors duration-200 hover:bg-tuna/90"
         draggable="true"
         onClick={(e) => {
           e.stopPropagation();

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,0 +1,9 @@
+## Naming methodology
+
+- Colors named with [Name that Color](https://chir.ag/projects/name-that-color).
+- Adjectives like "very" and suffixes like "ish" are not used.
+
+## Resources
+
+1. https://chir.ag/projects/name-that-color
+2. https://tailwindcss.com/docs/customizing-colors

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,11 @@ module.exports = {
   ],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'tuna': '#343541',
+      },
+    },
   },
   variants: {
     extend: {


### PR DESCRIPTION
Hello! 👋

Excellent work with this project! It's feature rich, and more than a clone. You've added delightful functionality that extends ChatGPT and adds true value. 

I started simple to understand the project structure. I noticed that the code may benefit from extending the color configuration to allow people to theme the application. I refactored the repeated color #343541 into the config. I also provided the naming rationale in the docs. 

If this change makes sense, I can continue with the other custom colors. I can submit them one at a time, or all at once - whatever is easiest to review.