### PR TITLE
Add Docker prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ brew install supabase/tap/supabase
 
 2. Start Supabase
 
+Prerequisite: Docker needs to be installed and running. For installation, visit the [official docs](https://docs.docker.com/get-docker/).
+
 ```bash
 supabase start
 ```


### PR DESCRIPTION
This PR updates the README to mention Docker as a prerequisite for running Supabase locally.