### PR TITLE
Improve placeholder text in chatbox to mention @ and / commands

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -106,7 +106,7 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
         <TextareaAutosize
           textareaRef={chatInputRef}
           className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md flex w-full resize-none rounded-md border-none bg-transparent px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-          placeholder="Send a message..."
+          placeholder="Send a message... (Use @ to reference files, / to reference prompts)"
           onValueChange={handleInputChange}
           value={userInput}
           minRows={1}

--- a/components/ui/chat-settings-form.tsx
+++ b/components/ui/chat-settings-form.tsx
@@ -58,7 +58,7 @@ export const ChatSettingsForm: FC<ChatSettingsFormProps> = ({
 
         <TextareaAutosize
           className="bg-background border-input border-2"
-          placeholder="Send a message..."
+          placeholder="Send a message... (Use @ to reference files, / to reference prompts)"
           onValueChange={prompt => {
             onChangeChatSettings({ ...chatSettings, prompt })
           }}


### PR DESCRIPTION
This PR tells users how to refer to uploaded files and prompts in a workspace using @ and / commands. 

It took quite a while to figure out how to access uploaded files in user queries. Before stumbling on the twitter post at #1047 I had to manually add the same file for each new chat :(

Since this is a useful feature, it would be nice to have a bit more guidance for new users. Screenshots below show a Before Vs After comparison. The only difference is in the text in the chatbox.

![image](https://github.com/mckaywrigley/chatbot-ui/assets/114123946/01df365e-96f0-40c8-8674-b098d13449c2)

![image](https://github.com/mckaywrigley/chatbot-ui/assets/114123946/a30ec3bc-e9b2-4fd7-bd84-28ff3e40aabd)


