### PR TITLE
Fixes double loading spinner when landing on /chat

### DIFF
--- a/components/chat/chat-ui.tsx
+++ b/components/chat/chat-ui.tsx
@@ -189,9 +189,9 @@ export const ChatUI: FC<ChatUIProps> = ({}) => {
     })
   }
 
-  // if (loading) {
-  //   return <Loading />
-  // }
+  if (loading) {
+    return <Loading />
+  }
 
   return (
     <div className="relative flex h-full flex-col items-center">

--- a/components/chat/chat-ui.tsx
+++ b/components/chat/chat-ui.tsx
@@ -189,9 +189,9 @@ export const ChatUI: FC<ChatUIProps> = ({}) => {
     })
   }
 
-  if (loading) {
-    return <Loading />
-  }
+  // if (loading) {
+  //   return <Loading />
+  // }
 
   return (
     <div className="relative flex h-full flex-col items-center">

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -118,7 +118,8 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
   }, [])
 
   useEffect(() => {
-    if (!selectedWorkspace) {
+    const isInChat = window?.location?.pathname === "/chat"
+    if (!selectedWorkspace && !isInChat) {
       setLoading(false)
       return
     }
@@ -136,7 +137,9 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
     setNewMessageImages([])
     setShowFilesDisplay(false)
 
-    fetchData(selectedWorkspace.id)
+    if (selectedWorkspace?.id) {
+      fetchData(selectedWorkspace.id)
+    }
   }, [selectedWorkspace])
 
   const fetchStartingData = async () => {
@@ -242,10 +245,6 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
   }
 
   const fetchOllamaModels = async () => {
-    if (!process.env.NEXT_PUBLIC_OLLAMA_URL) {
-      return
-    }
-
     setLoading(true)
 
     try {

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -242,6 +242,10 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
   }
 
   const fetchOllamaModels = async () => {
+    if (!process.env.NEXT_PUBLIC_OLLAMA_URL) {
+      return
+    }
+
     setLoading(true)
 
     try {

--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -119,6 +119,7 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
 
   useEffect(() => {
     const isInChat = window?.location?.pathname === "/chat"
+
     if (!selectedWorkspace && !isInChat) {
       setLoading(false)
       return


### PR DESCRIPTION
It seems that the !selectedWorkspace check was for when a user signs up, to enable them to move forward through the steps.

I did the whole signup flow and all is well because of the check on `/chat`👌 