### PR TITLE
Fix: Excludes auth from middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -57,5 +57,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: "/((?!api|static|.*\\..*|_next).*)"
+  matcher: "/((?!api|static|.*\\..*|_next|auth).*)"
 }


### PR DESCRIPTION
This PR introduces a small yet crucial change to the middleware configuration. The modification ensures that requests to the /auth path are no longer processed by the middleware, which was previously causing issues with the password recovery flow.