### PR TITLE
Solve the garbled issue of Chinese/Japanese/Korean

### DIFF
--- a/lib/consume-stream.ts
+++ b/lib/consume-stream.ts
@@ -17,7 +17,7 @@ export async function consumeReadableStream(
       }
 
       if (value) {
-        callback(decoder.decode(value))
+        callback(decoder.decode(value, { stream: true }))
       }
     }
   } catch (error) {


### PR DESCRIPTION
this pull request is to solve issues mentioned at https://github.com/mckaywrigley/chatbot-ui/issues/1171#issuecomment-1913188903

This is my first contribution. I am happy to share my excitement with you.

At first, we thought it may be resulted from the combo of Vercel and OpenAi. However, I checked the Vercel/Ai repo, and this problem has been address before. I deployed the openai example of Vercel/ai repo at vercel. It could deal with Chinese language pretty well. I believe it is a bug.

I dived into this project to find where the bug is. Characters are returned by chunk, so I add "1" between each chunk.
<img width="997" alt="Screenshot 2024-01-28 at 12 06 41 AM" src="https://github.com/mckaywrigley/chatbot-ui/assets/21181784/a0d6957e-024b-41b5-a3a9-29e29ffd5fe0">
Clearly, the chunk is not complete, and the garble issue happens. 

Then, I found the decode function of each chunk  `callback(decoder.decode(value))` at the lib/consume-stream.ts
This function was mentioned in this issue. 
https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/507

I believe, following correction can solve problem:
`callback(decoder.decode(value, { stream: true }))`

After testing. There is no more garbled issues.

<img width="997" alt="Screenshot 2024-01-28 at 12 12 33 AM" src="https://github.com/mckaywrigley/chatbot-ui/assets/21181784/bfac9dc0-7311-4e5a-a1cc-623dd4bd35f0">

People who deployed project at Netlify and files uploading issues happened, could keep using Vercel with this commit. 
https://github.com/mckaywrigley/chatbot-ui/issues/1283#issuecomment-1912350380

