### PR TITLE
set max width for model tooltip

### DIFF
--- a/components/chat/chat-secondary-buttons.tsx
+++ b/components/chat/chat-secondary-buttons.tsx
@@ -21,7 +21,7 @@ export const ChatSecondaryButtons: FC<ChatSecondaryButtonsProps> = ({}) => {
               <div>
                 <div className="text-xl font-bold">Chat Info</div>
 
-                <div className="mt-2 space-y-2">
+                <div className="mx-auto mt-2 max-w-xs space-y-2 sm:max-w-sm md:max-w-md lg:max-w-lg">
                   <div>Model: {selectedChat.model}</div>
                   <div>Prompt: {selectedChat.prompt}</div>
 

--- a/components/messages/message.tsx
+++ b/components/messages/message.tsx
@@ -198,7 +198,7 @@ export const Message: FC<MessageProps> = ({
                   )
                 ) : (
                   <WithTooltip
-                    display={<div>{MODEL_DATA.modelName}</div>}
+                    display={<div>{MODEL_DATA?.modelName}</div>}
                     trigger={
                       <ModelIcon
                         modelId={message.model as LLMID}


### PR DESCRIPTION
Simple fix to not have the tooltip too wide if for example long prompt. 

Also small addition to solve console error. 