### PR TITLE
Don't insert project ref in the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Login to Supabase by running:
 supabase login
 ```
 
-Next, link your project by running the following command with the "Project Ref" and "Project ID" you got above:
+Next, link your project by running the following command with the "Project ID" you got above:
 
 ```bash
 supabase link --project-ref <project-id>


### PR DESCRIPTION
The description currently says that --project-ref should be changed to the project ID string. I'm pretty sure that's wrong.