### PR TITLE
Support multiple JSON objects in Ollama stream chunk

### DIFF
--- a/components/chat/chat-helpers/index.ts
+++ b/components/chat/chat-helpers/index.ts
@@ -298,7 +298,19 @@ export const processResponse = async (
         setToolInUse("none")
 
         try {
-          contentToAdd = isHosted ? chunk : JSON.parse(chunk).message.content
+          contentToAdd = isHosted
+            ? chunk
+            : // Ollama's streaming endpoint returns new-line separated JSON
+              // objects. A chunk may have more than one of these objects, so we
+              // need to split the chunk by new-lines and handle each one
+              // separately.
+              chunk
+                .trimEnd()
+                .split("\n")
+                .reduce(
+                  (acc, line) => acc + JSON.parse(line).message.content,
+                  ""
+                )
           fullText += contentToAdd
         } catch (error) {
           console.error("Error parsing JSON:", error)


### PR DESCRIPTION
In some cases Ollama can send more than one JSON object in a single chunk of the streamed response. These are separated with new-line characters and are thus not valid JSON as-is. This change splits the chunk by new-lines and parses them individually.

I believe this fixes #1271.