### PR TITLE
feat: disable submitting buttons on login page

### DIFF
--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -1,7 +1,7 @@
 import { Brand } from "@/components/ui/brand"
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { SubmitButton } from "@/components/ui/submit-button"
 import { createClient } from "@/lib/supabase/server"
 import { Database } from "@/supabase/types"
 import { createServerClient } from "@supabase/ssr"
@@ -190,16 +190,16 @@ export default async function Login({
           placeholder="••••••••"
         />
 
-        <Button className="mb-2 rounded-md bg-blue-700 px-4 py-2 text-white">
+        <SubmitButton className="mb-2 rounded-md bg-blue-700 px-4 py-2 text-white">
           Login
-        </Button>
+        </SubmitButton>
 
-        <Button
+        <SubmitButton
           formAction={signUp}
           className="border-foreground/20 mb-2 rounded-md border px-4 py-2"
         >
           Sign Up
-        </Button>
+        </SubmitButton>
 
         <div className="text-muted-foreground mt-1 flex justify-center text-sm">
           <span className="mr-1">Forgot your password?</span>

--- a/components/ui/submit-button.tsx
+++ b/components/ui/submit-button.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import React from "react"
+import { useFormStatus } from "react-dom"
+import { Button, ButtonProps } from "./button"
+
+const SubmitButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => {
+    const { pending } = useFormStatus()
+
+    return <Button disabled={pending} ref={ref} {...props} />
+  }
+)
+
+SubmitButton.displayName = "SubmitButton"
+
+export { SubmitButton }


### PR DESCRIPTION
I encountered a problem with the UI on the login page where the buttons did not show users that their click was registered. I didn't know who to solve it properly, because the page is rendered on the server side. 
To solve this, I decided to disable the buttons after they are clicked. I created a new SubmitButton component that replaces the standard buttons on the login/sign-up form.
After triggering any submit action (sign-in/sign-up/reset), all buttons are disabled.
This at least provides some clear feedback to users by showing that their action is being processed.