### PR TITLE
Allow inactive chats to be renamed and deleted via sidebar buttons

### DIFF
--- a/components/sidebar/items/chat/chat-item.tsx
+++ b/components/sidebar/items/chat/chat-item.tsx
@@ -57,7 +57,7 @@ export const ChatItem: FC<ChatItemProps> = ({ chat }) => {
     <div
       ref={itemRef}
       className={cn(
-        "hover:bg-accent focus:bg-accent flex w-full cursor-pointer items-center rounded p-2 hover:opacity-50 focus:outline-none",
+        "hover:bg-accent focus:bg-accent group flex w-full cursor-pointer items-center rounded p-2 hover:opacity-50 focus:outline-none",
         isActive && "bg-accent"
       )}
       tabIndex={0}
@@ -93,19 +93,17 @@ export const ChatItem: FC<ChatItemProps> = ({ chat }) => {
         {chat.name}
       </div>
 
-      {isActive && (
-        <div
-          onClick={e => {
-            e.stopPropagation()
-            e.preventDefault()
-          }}
-          className="ml-2 flex space-x-2"
-        >
-          <UpdateChat chat={chat} />
+      <div
+        onClick={e => {
+          e.stopPropagation()
+          e.preventDefault()
+        }}
+        className={`ml-2 flex space-x-2 ${!isActive && "w-11 opacity-0 group-hover:opacity-100"}`}
+      >
+        <UpdateChat chat={chat} />
 
-          <DeleteChat chat={chat} />
-        </div>
-      )}
+        <DeleteChat chat={chat} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
This is useful as loading a new chat currently takes over 20 HTTP requests over the course of 2000 ms for me.
Maybe I will try to figure out what's causing this delay soon.
![image](https://github.com/mckaywrigley/chatbot-ui/assets/59662605/c9e3d81e-d709-4e3d-b8b1-7ad77476f323)

I've made it so that the buttons are displayed on hover:
![image](https://github.com/mckaywrigley/chatbot-ui/assets/59662605/7ac71d91-425f-4a54-bd47-cf6d2c64022e)
