### PR TITLE
fix: enable mask for pwa on macos

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,7 +15,8 @@
     {
       "src": "/icon-512x512.png",
       "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose":"maskable"
     }
   ],
   "start_url": "/",


### PR DESCRIPTION

<img width="192" alt="image" src="https://github.com/mckaywrigley/chatbot-ui/assets/18362928/6414eaaf-4340-493a-bd00-f88d5bb1109d">

It's disturbing to see squared icon in PWA mode :D
Here's a small tweak to fix it