### PR TITLE
fix forget password

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,6 +8,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Ollama
 NEXT_PUBLIC_OLLAMA_URL=http://localhost:11434
 
+# Your Website URL
+NEXT_PUBLIC_PRODUCTION_ORIGIN=
+
 # API Keys (Optional: Entering an API key here overrides the API keys globally for all users.)
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -14,8 +14,9 @@ export async function GET(request: Request) {
   }
 
   if (next) {
-    return NextResponse.redirect(requestUrl.origin + next)
+    // requestUrl.origin returns `localhost:3000`, manually override from .env.local
+    return NextResponse.redirect(process.env.NEXT_PUBLIC_PRODUCTION_ORIGIN! || requestUrl.origin + next)
   } else {
-    return NextResponse.redirect(requestUrl.origin)
+    return NextResponse.redirect(process.env.NEXT_PUBLIC_PRODUCTION_ORIGIN! || requestUrl.origin)
   }
 }

--- a/components/utility/change-password.tsx
+++ b/components/utility/change-password.tsx
@@ -23,6 +23,8 @@ export const ChangePassword: FC<ChangePasswordProps> = () => {
 
   const handleResetPassword = async () => {
     if (!newPassword) return alert("Please enter your new password.")
+    if (newPassword !== confirmPassword)
+      return alert("Your password's don't match.")
 
     await supabase.auth.updateUser({ password: newPassword })
 


### PR DESCRIPTION
in `/auth/callback`, `requestUrl.origin` was returning `localhost:3000` rather than the URL that chatbot-ui was hosted on
