### PR TITLE
fix text completion bug

### DIFF
--- a/components/chat/chat-hooks/use-chat-handler.tsx
+++ b/components/chat/chat-hooks/use-chat-handler.tsx
@@ -158,8 +158,6 @@ export const useChatHandler = () => {
     chatMessages: ChatMessage[],
     isRegeneration: boolean
   ) => {
-    const startingInput = messageContent
-
     try {
       setUserInput("")
       setIsGenerating(true)
@@ -351,7 +349,6 @@ export const useChatHandler = () => {
     } catch (error) {
       setIsGenerating(false)
       setFirstTokenReceived(false)
-      setUserInput(startingInput)
     }
   }
 


### PR DESCRIPTION
while the llm is generating text and you type text into the text input, when the llm finishes, it would copy the initial query back into the text input box, removing what you wrote. this fixes that.