### PR TITLE
fix(workspace-settings): Add maxLength Prop to Textarea Component

### DIFF
--- a/components/ui/textarea-autosize.tsx
+++ b/components/ui/textarea-autosize.tsx
@@ -12,6 +12,7 @@ interface TextareaAutosizeProps {
   placeholder?: string
   minRows?: number
   maxRows?: number
+  maxLength?: number
   onKeyDown?: (event: React.KeyboardEvent) => void
   onPaste?: (event: React.ClipboardEvent) => void
   onCompositionStart?: (event: React.CompositionEvent) => void
@@ -21,12 +22,12 @@ interface TextareaAutosizeProps {
 export const TextareaAutosize: FC<TextareaAutosizeProps> = ({
   value,
   onValueChange,
-
   textareaRef,
   className,
   placeholder = "",
   minRows = 1,
   maxRows = 6,
+  maxLength,
   onKeyDown = () => {},
   onPaste = () => {},
   onCompositionStart = () => {},
@@ -43,6 +44,7 @@ export const TextareaAutosize: FC<TextareaAutosizeProps> = ({
       maxRows={minRows > maxRows ? minRows : maxRows}
       placeholder={placeholder}
       value={value}
+      maxLength={maxLength}
       onChange={event => onValueChange(event.target.value)}
       onKeyDown={onKeyDown}
       onPaste={onPaste}

--- a/components/workspace/workspace-settings.tsx
+++ b/components/workspace/workspace-settings.tsx
@@ -251,6 +251,7 @@ export const WorkspaceSettings: FC<WorkspaceSettingsProps> = ({}) => {
                   onValueChange={setInstructions}
                   minRows={5}
                   maxRows={10}
+                  maxLength={1500}
                 />
 
                 <LimitDisplay


### PR DESCRIPTION
**PR Description**:
This PR introduces a new prop, `maxLength`, to the `TextareaAutosize` component in the workspace settings. The `maxLength` prop allows limiting the maximum length of the input value within the textarea, providing users with enhanced control over their input.

**Changes Made**:
- Added the `maxLength` prop to the `TextareaAutosize` component to enforce the character limit.
- Updated the component's type definition to include the `maxLength` prop.

#1500 
  