### PR TITLE
Fix Assistant issues on new chat and quick settings when deselected

### DIFF
--- a/components/chat/chat-hooks/use-chat-handler.tsx
+++ b/components/chat/chat-hooks/use-chat-handler.tsx
@@ -17,6 +17,10 @@ import {
   processResponse,
   validateChatSettings
 } from "../chat-helpers"
+import { getAssistantFilesByAssistantId } from "@/db/assistant-files"
+import { getAssistantCollectionsByAssistantId } from "@/db/assistant-collections"
+import { getCollectionFilesByCollectionId } from "@/db/collection-files"
+import { getAssistantToolsByAssistantId } from "@/db/assistant-tools"
 
 export const useChatHandler = () => {
   const router = useRouter()
@@ -108,6 +112,37 @@ export const useChatHandler = () => {
           | "openai"
           | "local"
       })
+
+      let allFiles = []
+
+      const assistantFiles = (
+        await getAssistantFilesByAssistantId(selectedAssistant.id)
+      ).files
+      allFiles = [...assistantFiles]
+      const assistantCollections = (
+        await getAssistantCollectionsByAssistantId(selectedAssistant.id)
+      ).collections
+      for (const collection of assistantCollections) {
+        const collectionFiles = (
+          await getCollectionFilesByCollectionId(collection.id)
+        ).files
+        allFiles = [...allFiles, ...collectionFiles]
+      }
+      const assistantTools = (
+        await getAssistantToolsByAssistantId(selectedAssistant.id)
+      ).tools
+
+      setSelectedTools(assistantTools)
+      setChatFiles(
+        allFiles.map(file => ({
+          id: file.id,
+          name: file.name,
+          type: file.type,
+          file: null
+        }))
+      )
+
+      if (allFiles.length > 0) setShowFilesDisplay(true)
     } else if (selectedPreset) {
       setChatSettings({
         model: selectedPreset.model as LLMID,

--- a/components/chat/quick-settings.tsx
+++ b/components/chat/quick-settings.tsx
@@ -20,6 +20,7 @@ import {
 } from "../ui/dropdown-menu"
 import { Input } from "../ui/input"
 import { QuickSettingOption } from "./quick-setting-option"
+import { set } from "date-fns"
 
 interface QuickSettingsProps {}
 
@@ -40,7 +41,8 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
     assistantImages,
     setChatFiles,
     setSelectedTools,
-    setShowFilesDisplay
+    setShowFilesDisplay,
+    selectedWorkspace
   } = useContext(ChatbotUIContext)
 
   const inputRef = useRef<HTMLInputElement>(null)
@@ -58,16 +60,14 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
   }, [isOpen])
 
   const handleSelectQuickSetting = async (
-    item: Tables<"presets"> | Tables<"assistants">,
-    contentType: "presets" | "assistants"
+    item: Tables<"presets"> | Tables<"assistants"> | null,
+    contentType: "presets" | "assistants" | "remove"
   ) => {
-    if (contentType === "assistants") {
+    console.log({ item, contentType })
+    if (contentType === "assistants" && item) {
       setSelectedAssistant(item as Tables<"assistants">)
-
       setLoading(true)
-
       let allFiles = []
-
       const assistantFiles = (await getAssistantFilesByAssistantId(item.id))
         .files
       allFiles = [...assistantFiles]
@@ -82,7 +82,6 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
       }
       const assistantTools = (await getAssistantToolsByAssistantId(item.id))
         .tools
-
       setSelectedTools(assistantTools)
       setChatFiles(
         allFiles.map(file => ({
@@ -92,15 +91,34 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
           file: null
         }))
       )
-
       if (allFiles.length > 0) setShowFilesDisplay(true)
-
       setLoading(false)
-
       setSelectedPreset(null)
-    } else if (contentType === "presets") {
+    } else if (contentType === "presets" && item) {
       setSelectedPreset(item as Tables<"presets">)
       setSelectedAssistant(null)
+      setChatFiles([])
+      setSelectedTools([])
+    } else {
+      setSelectedPreset(null)
+      setSelectedAssistant(null)
+      setChatFiles([])
+      setSelectedTools([])
+      if (selectedWorkspace) {
+        setChatSettings({
+          model: selectedWorkspace.default_model as LLMID,
+          prompt: selectedWorkspace.default_prompt,
+          temperature: selectedWorkspace.default_temperature,
+          contextLength: selectedWorkspace.default_context_length,
+          includeProfileContext: selectedWorkspace.include_profile_context,
+          includeWorkspaceInstructions:
+            selectedWorkspace.include_workspace_instructions,
+          embeddingsProvider: selectedWorkspace.embeddings_provider as
+            | "openai"
+            | "local"
+        })
+      }
+      return
     }
 
     setChatSettings({
@@ -118,20 +136,18 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
     if (!chatSettings) return false
 
     if (selectedPreset) {
-      if (
+      return (
         selectedPreset.include_profile_context !==
-          chatSettings.includeProfileContext ||
+          chatSettings?.includeProfileContext ||
         selectedPreset.include_workspace_instructions !==
           chatSettings.includeWorkspaceInstructions ||
         selectedPreset.context_length !== chatSettings.contextLength ||
         selectedPreset.model !== chatSettings.model ||
         selectedPreset.prompt !== chatSettings.prompt ||
         selectedPreset.temperature !== chatSettings.temperature
-      ) {
-        return true
-      }
+      )
     } else if (selectedAssistant) {
-      if (
+      return (
         selectedAssistant.include_profile_context !==
           chatSettings.includeProfileContext ||
         selectedAssistant.include_workspace_instructions !==
@@ -140,9 +156,7 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
         selectedAssistant.model !== chatSettings.model ||
         selectedAssistant.prompt !== chatSettings.prompt ||
         selectedAssistant.temperature !== chatSettings.temperature
-      ) {
-        return true
-      }
+      )
     }
 
     return false
@@ -250,8 +264,7 @@ export const QuickSettings: FC<QuickSettingsProps> = ({}) => {
                     | Tables<"assistants">)
                 }
                 onSelect={() => {
-                  setSelectedPreset(null)
-                  setSelectedAssistant(null)
+                  handleSelectQuickSetting(null, "remove")
                 }}
                 image={selectedPreset ? "" : selectedAssistantImage}
               />


### PR DESCRIPTION
Fixes two issues around assistants:
1. With an assistant selected, creating a new chat, removes the files and tools
2. If you remove an assistant on Quick Settings, prompt, tools and files remain on the chat.