### PR TITLE
Tools API: Prevent second OpenAI call when no tools used

### DIFF
--- a/app/api/chat/tools/route.ts
+++ b/app/api/chat/tools/route.ts
@@ -69,6 +69,14 @@ export async function POST(request: Request) {
     messages.push(message)
     const toolCalls = message.tool_calls || []
 
+    if (toolCalls.length === 0) {
+      return new Response(message.content, {
+        headers: {
+          "Content-Type": "application/json"
+        }
+      })
+    }
+
     if (toolCalls.length > 0) {
       for (const toolCall of toolCalls) {
         const functionCall = toolCall.function


### PR DESCRIPTION
Opt to return the initial model response directly.

During testing, it was observed that if the OpenAI model provides a high-quality response without utilising any tools, a subsequent call to the model tends to yield a significantly reduced quality in the "final" answer. To enhance efficiency and maintain response quality, this update avoids an unnecessary second invocation of the OpenAI model when no tools are engaged in the process.