### PR TITLE
Solve the problem of displaying repeated words during the streaming process in Chinese and other languages.

### DIFF
--- a/components/chat/chat-helpers/index.ts
+++ b/components/chat/chat-helpers/index.ts
@@ -325,7 +325,7 @@ export const processResponse = async (
               const updatedChatMessage: ChatMessage = {
                 message: {
                   ...chatMessage.message,
-                  content: chatMessage.message.content + contentToAdd
+                  content: fullText
                 },
                 fileItems: chatMessage.fileItems
               }


### PR DESCRIPTION
When I generate Chinese characters, during streaming process, words occasionally repeats itself or neighbor chunks. When generation is finished, the full content will fresh and saved to database. This happened frequently on the vercel deployments and sometimes on the local deployments, across all types of models hosted outside Asia (openai, mistral, anthropic, openrouter).  
It is not too painful to wait until it finished. However, new models like claude-3 can generate really good and pretty long content, this issue got higher priority.
I checked how the processResponse function behaves. Streaming outputs are updated by 
`content: chatMessage.message.content + contentToAdd`
This is pretty clear and straight. However it may increase potential critical computation latency, considering the content will be displayed immediately. I update this content by the fullText directly as 
`content: fullText`,
because fullText variable keeps accumulating contentToAdd, behaving the same way as the original
`content: chatMessage.message.content + contentToAdd`.

Problem example:
During streaming, (repeated words happened):
<img width="781" alt="Screenshot 2024-03-11 at 8 22 17 PM" src="https://github.com/mckaywrigley/chatbot-ui/assets/21181784/58ca8380-f9ff-4191-9eaa-d13f858ff863">
Finished, (repeated words are corrected after finishing):
<img width="781" alt="Screenshot 2024-03-11 at 8 22 38 PM" src="https://github.com/mckaywrigley/chatbot-ui/assets/21181784/cf53b4c2-de44-44ec-bf19-a70a9f848945">

After this commit:
During streaming, (no more issues):
<img width="840" alt="Screenshot 2024-03-11 at 8 23 30 PM" src="https://github.com/mckaywrigley/chatbot-ui/assets/21181784/89291427-82f1-4e6b-b7e8-0cdc4151b6f7">
There is no more repeated words.

If after this commit other developers still encounter the same problem, please comment.