### PR TITLE
Allow the use of Custom Endpoints\Proxies for OpenAI

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -31,3 +31,6 @@ AZURE_EMBEDDINGS_NAME=
 # General Configuration (Optional)
 EMAIL_DOMAIN_WHITELIST=
 EMAIL_WHITELIST=
+
+# (Optional) Only define if you wish to use
+#ENDPOINT_OPENAI=       #Will only be used if defined.  Put your API proxy or custom endpoint here, eg: Cloudflare AI https://gateway.ai.cloudflare.com/v1/<gatewayid>/<gateway-name>/openai

--- a/app/api/assistants/openai/route.ts
+++ b/app/api/assistants/openai/route.ts
@@ -12,7 +12,8 @@ export async function GET() {
 
     const openai = new OpenAI({
       apiKey: profile.openai_api_key || "",
-      organization: profile.openai_organization_id
+      organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
     })
 
     const myAssistants = await openai.beta.assistants.list({

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -21,7 +21,8 @@ export async function POST(request: Request) {
 
     const openai = new OpenAI({
       apiKey: profile.openai_api_key || "",
-      organization: profile.openai_organization_id
+      organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
     })
 
     const response = await openai.chat.completions.create({

--- a/app/api/chat/tools/route.ts
+++ b/app/api/chat/tools/route.ts
@@ -21,7 +21,8 @@ export async function POST(request: Request) {
 
     const openai = new OpenAI({
       apiKey: profile.openai_api_key || "",
-      organization: profile.openai_organization_id
+      organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
     })
 
     let allTools: OpenAI.Chat.Completions.ChatCompletionTool[] = []

--- a/app/api/command/route.ts
+++ b/app/api/command/route.ts
@@ -17,7 +17,8 @@ export async function POST(request: Request) {
 
     const openai = new OpenAI({
       apiKey: profile.openai_api_key || "",
-      organization: profile.openai_organization_id
+      organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
     })
 
     const response = await openai.chat.completions.create({

--- a/app/api/retrieval/process/docx/route.ts
+++ b/app/api/retrieval/process/docx/route.ts
@@ -57,7 +57,8 @@ export async function POST(req: Request) {
     } else {
       openai = new OpenAI({
         apiKey: profile.openai_api_key || "",
-        organization: profile.openai_organization_id
+        organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
       })
     }
 

--- a/app/api/retrieval/process/route.ts
+++ b/app/api/retrieval/process/route.ts
@@ -77,7 +77,8 @@ export async function POST(req: Request) {
     } else {
       openai = new OpenAI({
         apiKey: profile.openai_api_key || "",
-        organization: profile.openai_organization_id
+        organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
       })
     }
 

--- a/app/api/retrieval/retrieve/route.ts
+++ b/app/api/retrieval/retrieve/route.ts
@@ -44,7 +44,8 @@ export async function POST(request: Request) {
     } else {
       openai = new OpenAI({
         apiKey: profile.openai_api_key || "",
-        organization: profile.openai_organization_id
+        organization: profile.openai_organization_id,
+	  ...(process.env.ENDPOINT_OPENAI && { baseURL: process.env.ENDPOINT_OPENAI })
       })
     }
 


### PR DESCRIPTION
Minor update that may help other that wish to use either custom end-points or an API proxy such as Cloudflare AI Gateway.
Apologies if this is inefficient or incomplete I can't code, used GPT-4 to guide me.

Why use an AI Gateway?
- Caching (you need to enable this, but not really beneficial, due to the uniqueness of each query)
- Improved Visibility (potentially a privacy issue for some), but useful during debugging
- Ratelimiting