### PR TITLE
Mobile UI Improvements

### DIFF
--- a/app/[locale]/[workspaceid]/chat/page.tsx
+++ b/app/[locale]/[workspaceid]/chat/page.tsx
@@ -42,7 +42,7 @@ export default function ChatPage() {
 
           <div className="flex grow flex-col items-center justify-center" />
 
-          <div className="w-[300px] pb-8 sm:w-[400px] md:w-[500px] lg:w-[660px] xl:w-[800px]">
+          <div className="w-full min-w-[300px] items-end px-2 pb-3 pt-0 sm:w-[600px] sm:pb-8 sm:pt-5 md:w-[700px] lg:w-[700px] xl:w-[800px]">
             <ChatInput />
           </div>
 

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -96,7 +96,7 @@ export default async function RootLayout({
             resources={resources}
           >
             <Toaster richColors position="top-center" duration={3000} />
-            <div className="bg-background text-foreground flex h-screen flex-col items-center">
+            <div className="bg-background text-foreground flex h-dvh flex-col items-center overflow-x-auto">
               {session ? <GlobalState>{children}</GlobalState> : children}
             </div>
           </TranslationsProvider>

--- a/components/chat/chat-hooks/use-scroll.tsx
+++ b/components/chat/chat-hooks/use-scroll.tsx
@@ -69,7 +69,7 @@ export const useScroll = () => {
       }
 
       isAutoScrolling.current = false
-    }, 0)
+    }, 100)
   }, [])
 
   return {

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -240,7 +240,8 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
           textareaRef={chatInputRef}
           className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md flex w-full resize-none rounded-md border-none bg-transparent px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           placeholder={t(
-            `Ask anything. Type "@" for assistants, "/" for prompts, "#" for files, and "!" for tools.`
+            // `Ask anything. Type "@" for assistants, "/" for prompts, "#" for files, and "!" for tools.`
+            `Ask anything. Type @  /  #  !`
           )}
           onValueChange={handleInputChange}
           value={userInput}

--- a/components/chat/chat-ui.tsx
+++ b/components/chat/chat-ui.tsx
@@ -201,8 +201,8 @@ export const ChatUI: FC<ChatUIProps> = ({}) => {
         <ChatSecondaryButtons />
       </div>
 
-      <div className="bg-secondary flex max-h-[50px] min-h-[50px] w-full items-center justify-center border-b-2 px-20 font-bold">
-        <div className="max-w-[300px] truncate sm:max-w-[400px] md:max-w-[500px] lg:max-w-[600px] xl:max-w-[700px]">
+      <div className="bg-secondary flex max-h-[50px] min-h-[50px] w-full items-center justify-center border-b-2 font-bold">
+        <div className="max-w-[200px] truncate sm:max-w-[400px] md:max-w-[500px] lg:max-w-[600px] xl:max-w-[700px]">
           {selectedChat?.name || "Chat"}
         </div>
       </div>
@@ -218,7 +218,7 @@ export const ChatUI: FC<ChatUIProps> = ({}) => {
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="relative w-[300px] items-end pb-8 pt-5 sm:w-[400px] md:w-[500px] lg:w-[660px] xl:w-[800px]">
+      <div className="relative w-full min-w-[300px] items-end px-2 pb-3 pt-0 sm:w-[600px] sm:pb-8 sm:pt-5 md:w-[700px] lg:w-[700px] xl:w-[800px]">
         <ChatInput />
       </div>
 

--- a/components/messages/message.tsx
+++ b/components/messages/message.tsx
@@ -189,8 +189,8 @@ export const Message: FC<MessageProps> = ({
       onMouseLeave={() => setIsHovering(false)}
       onKeyDown={handleKeyDown}
     >
-      <div className="relative flex w-[300px] flex-col py-6 sm:w-[400px] md:w-[500px] lg:w-[600px] xl:w-[700px]">
-        <div className="absolute right-0 top-7">
+      <div className="relative flex w-full flex-col p-6 sm:w-[550px] sm:px-0 md:w-[650px] lg:w-[650px] xl:w-[700px]">
+        <div className="absolute right-5 top-7 sm:right-0">
           <MessageActions
             onCopy={handleCopy}
             onEdit={handleStartEdit}
@@ -263,6 +263,7 @@ export const Message: FC<MessageProps> = ({
                       ? selectedAssistant?.name
                       : MODEL_DATA?.modelName
                   : profile?.display_name ?? profile?.username}
+                {message.role === "user" ? "You" : ""}
               </div>
             </div>
           )}

--- a/components/ui/dashboard.tsx
+++ b/components/ui/dashboard.tsx
@@ -71,23 +71,10 @@ export const Dashboard: FC<DashboardProps> = ({ children }) => {
     <div className="flex size-full">
       <CommandK />
 
-      <Button
-        className={cn(
-          "absolute left-[4px] top-[50%] z-10 size-[32px] cursor-pointer"
-        )}
-        style={{
-          marginLeft: showSidebar ? `${SIDEBAR_WIDTH}px` : "0px",
-          transform: showSidebar ? "rotate(180deg)" : "rotate(0deg)"
-        }}
-        variant="ghost"
-        size="icon"
-        onClick={handleToggleSidebar}
-      >
-        <IconChevronCompactRight size={24} />
-      </Button>
-
       <div
-        className={cn("border-r-2 duration-200 dark:border-none")}
+        className={cn(
+          "duration-200 dark:border-none " + (showSidebar ? "border-r-2" : "")
+        )}
         style={{
           // Sidebar
           minWidth: showSidebar ? `${SIDEBAR_WIDTH}px` : "0px",
@@ -112,7 +99,7 @@ export const Dashboard: FC<DashboardProps> = ({ children }) => {
       </div>
 
       <div
-        className="bg-muted/50 flex grow flex-col"
+        className="bg-muted/50 relative flex w-screen min-w-[90%] grow flex-col sm:min-w-fit"
         onDrop={onFileDrop}
         onDragOver={onDragOver}
         onDragEnter={handleDragEnter}
@@ -125,6 +112,21 @@ export const Dashboard: FC<DashboardProps> = ({ children }) => {
         ) : (
           children
         )}
+
+        <Button
+          className={cn(
+            "absolute left-[4px] top-[50%] z-10 size-[32px] cursor-pointer"
+          )}
+          style={{
+            // marginLeft: showSidebar ? `${SIDEBAR_WIDTH}px` : "0px",
+            transform: showSidebar ? "rotate(180deg)" : "rotate(0deg)"
+          }}
+          variant="ghost"
+          size="icon"
+          onClick={handleToggleSidebar}
+        >
+          <IconChevronCompactRight size={24} />
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
Fix parts that degrade mobile experience (only on small screens)
- Margin adjustment
<img src="https://github.com/mckaywrigley/chatbot-ui/assets/160041450/f9e63641-3882-4d68-81f2-36d726e875c4" width="200"/> <img src="https://github.com/mckaywrigley/chatbot-ui/assets/160041450/42e86523-e073-4fed-90f3-8e8fd3c2940d" width="200"/>
- Remove bottom margin that appears when toggling the sidebar
(Fixed an issue where the chat on the right was not properly focused after clicking the sidebar chat list)
<img src="https://github.com/mckaywrigley/chatbot-ui/assets/160041450/c3475318-4280-415e-a81e-b4b78d240b04" width="200"/> <img src="https://github.com/mckaywrigley/chatbot-ui/assets/160041450/9164fd2b-22a2-481d-ab5b-2ed182e851f1" width="200"/> 
- Remove horizontal scrolling that occurs even when the sidebar is hidden (ios safari)
- etc

Please understand the awkwardness caused by the translator :)