### PR TITLE
Fix @anthropic-ai/sdk V Mismatch in package-lock.json (0.16.1 →  0.18.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,7 +149,7 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.16.1",
+      "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.18.0.tgz",
       "integrity": "sha512-vHgvfWEyFy5ktqam56Nrhv8MVa7EJthsRYNi+1OrFFfyrj9tR2/aji1QbVbQjYU/pPhPFaYrdCEC/MLPFrmKwA==",
       "dependencies": {


### PR DESCRIPTION
This Pull Request addresses a deployment issue caused by a version mismatch for the `@anthropic-ai/sdk` package between `package.json` and `package-lock.json`. In a previous commit, the version of `@anthropic-ai/sdk` was updated to `0.18.0` in `package.json`, but the corresponding update was not reflected in `package-lock.json`. This discrepancy led to a synchronization issue during the deployment process, as `npm ci` requires both files to be in sync to ensure a consistent installation environment.

#### Changes Made:
- Updated `package-lock.json` to match the version of `@anthropic-ai/sdk` specified in `package.json` (0.18.0).

#### Impact:
- Resolves the deployment issue related to the version mismatch.
- Ensures consistent dependency resolution for `@anthropic-ai/sdk` across development and deployment environments.

#### Testing:
- Local testing was conducted to verify that the application functions correctly with the updated `@anthropic-ai/sdk` version.
- Further testing in the deployment environment is recommended to confirm the resolution of the issue.

This PR aims to ensure that our dependency versions are aligned, thus mitigating potential issues related to inconsistent dependency resolution. Your review and feedback on these changes are greatly appreciated.