### PR TITLE
Feat/model pricing

### DIFF
--- a/components/models/model-option.tsx
+++ b/components/models/model-option.tsx
@@ -1,6 +1,8 @@
 import { LLM } from "@/types"
 import { FC } from "react"
 import { ModelIcon } from "./model-icon"
+import { IconInfoCircle } from "@tabler/icons-react"
+import { WithTooltip } from "../ui/with-tooltip"
 
 interface ModelOptionProps {
   model: LLM
@@ -9,15 +11,39 @@ interface ModelOptionProps {
 
 export const ModelOption: FC<ModelOptionProps> = ({ model, onSelect }) => {
   return (
-    <div
-      className="hover:bg-accent flex w-full cursor-pointer justify-start space-x-3 truncate rounded p-2 hover:opacity-50"
-      onClick={onSelect}
-    >
-      <div className="flex items-center space-x-2">
-        <ModelIcon provider={model.provider} width={28} height={28} />
-
-        <div className="text-sm font-semibold">{model.modelName}</div>
-      </div>
-    </div>
+    <WithTooltip
+      display={
+        <div>
+          {model.provider !== "ollama" && model.pricing && (
+            <div className="space-y-1 text-sm">
+              <div>
+                <span className="font-semibold">Input Cost:</span>{" "}
+                {model.pricing.inputCost} {model.pricing.currency} per{" "}
+                {model.pricing.unit}
+              </div>
+              {model.pricing.outputCost && (
+                <div>
+                  <span className="font-semibold">Output Cost:</span>{" "}
+                  {model.pricing.outputCost} {model.pricing.currency} per{" "}
+                  {model.pricing.unit}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      }
+      side="bottom"
+      trigger={
+        <div
+          className="hover:bg-accent flex w-full cursor-pointer justify-start space-x-3 truncate rounded p-2 hover:opacity-50"
+          onClick={onSelect}
+        >
+          <div className="flex items-center space-x-2">
+            <ModelIcon provider={model.provider} width={28} height={28} />
+            <div className="text-sm font-semibold">{model.modelName}</div>
+          </div>
+        </div>
+      }
+    />
   )
 }

--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -61,19 +61,19 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
     MAX_TOKEN_OUTPUT_LENGTH: 2000,
     MAX_CONTEXT_LENGTH: 8000
   },
-  "mistral-small": {
+  "mistral-small-latest": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,
     MAX_TOKEN_OUTPUT_LENGTH: 2000,
     MAX_CONTEXT_LENGTH: 32000
   },
-  "mistral-medium": {
+  "mistral-medium-latest": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,
     MAX_TOKEN_OUTPUT_LENGTH: 2000,
     MAX_CONTEXT_LENGTH: 32000
   },
-  "mistral-large-2402": {
+  "mistral-large-latest": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,
     MAX_TOKEN_OUTPUT_LENGTH: 2000,

--- a/lib/models/llm/anthropic-llm-list.ts
+++ b/lib/models/llm/anthropic-llm-list.ts
@@ -12,7 +12,13 @@ const CLAUDE_2: LLM = {
   provider: "anthropic",
   hostedId: "claude-2.1",
   platformLink: ANTHROPIC_PLATFORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 8,
+    outputCost: 24
+  }
 }
 
 // Claude Instant (UPDATED 12/21/23)
@@ -22,7 +28,13 @@ const CLAUDE_INSTANT: LLM = {
   provider: "anthropic",
   hostedId: "claude-instant-1.2",
   platformLink: ANTHROPIC_PLATFORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.8,
+    outputCost: 2.4
+  }
 }
 
 // Claude 3 Haiku (UPDATED 03/13/24)
@@ -32,7 +44,13 @@ const CLAUDE_3_HAIKU: LLM = {
   provider: "anthropic",
   hostedId: "claude-3-haiku-20240307",
   platformLink: ANTHROPIC_PLATFORM_LINK,
-  imageInput: true
+  imageInput: true,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.25,
+    outputCost: 1.25
+  }
 }
 
 // Claude 3 Sonnet (UPDATED 03/04/24)
@@ -42,7 +60,13 @@ const CLAUDE_3_SONNET: LLM = {
   provider: "anthropic",
   hostedId: "claude-3-sonnet-20240229",
   platformLink: ANTHROPIC_PLATFORM_LINK,
-  imageInput: true
+  imageInput: true,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 3,
+    outputCost: 15
+  }
 }
 
 // Claude 3 Opus (UPDATED 03/04/24)
@@ -52,7 +76,13 @@ const CLAUDE_3_OPUS: LLM = {
   provider: "anthropic",
   hostedId: "claude-3-opus-20240229",
   platformLink: ANTHROPIC_PLATFORM_LINK,
-  imageInput: true
+  imageInput: true,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 15,
+    outputCost: 75
+  }
 }
 
 export const ANTHROPIC_LLM_LIST: LLM[] = [

--- a/lib/models/llm/groq-llm-list.ts
+++ b/lib/models/llm/groq-llm-list.ts
@@ -8,7 +8,13 @@ const LLaMA2_70B: LLM = {
   provider: "groq",
   hostedId: "llama2-70b-4096",
   platformLink: GROQ_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.7,
+    outputCost: 0.8
+  }
 }
 
 const MIXTRAL_8X7B: LLM = {
@@ -17,7 +23,13 @@ const MIXTRAL_8X7B: LLM = {
   provider: "groq",
   hostedId: "mixtral-8x7b-32768",
   platformLink: GROQ_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.27,
+    outputCost: 0.27
+  }
 }
 
 export const GROQ_LLM_LIST: LLM[] = [LLaMA2_70B, MIXTRAL_8X7B]

--- a/lib/models/llm/mistral-llm-list.ts
+++ b/lib/models/llm/mistral-llm-list.ts
@@ -16,32 +16,50 @@ const MISTRAL_7B: LLM = {
 
 // Mixtral (UPDATED 12/21/23)
 const MIXTRAL: LLM = {
-  modelId: "mistral-small",
+  modelId: "mistral-small-latest",
   modelName: "Mistral Small",
   provider: "mistral",
-  hostedId: "mistral-small",
+  hostedId: "mistral-small-latest",
   platformLink: MISTRAL_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 2,
+    outputCost: 6
+  }
 }
 
 // Mistral Medium (UPDATED 12/21/23)
 const MISTRAL_MEDIUM: LLM = {
-  modelId: "mistral-medium",
+  modelId: "mistral-medium-latest",
   modelName: "Mistral Medium",
   provider: "mistral",
-  hostedId: "mistral-medium",
+  hostedId: "mistral-medium-latest",
   platformLink: MISTRAL_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 2.7,
+    outputCost: 8.1
+  }
 }
 
 // Mistral Large (UPDATED 03/05/24)
 const MISTRAL_LARGE: LLM = {
-  modelId: "mistral-large-2402",
+  modelId: "mistral-large-latest",
   modelName: "Mistral Large",
   provider: "mistral",
-  hostedId: "mistral-large-2402",
+  hostedId: "mistral-large-latest",
   platformLink: MISTRAL_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 8,
+    outputCost: 24
+  }
 }
 
 export const MISTRAL_LLM_LIST: LLM[] = [

--- a/lib/models/llm/openai-llm-list.ts
+++ b/lib/models/llm/openai-llm-list.ts
@@ -11,7 +11,13 @@ const GPT4Turbo: LLM = {
   provider: "openai",
   hostedId: "gpt-4-turbo-preview",
   platformLink: OPENAI_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 10,
+    outputCost: 30
+  }
 }
 
 // GPT-4 Vision (UPDATED 12/18/23)
@@ -21,7 +27,12 @@ const GPT4Vision: LLM = {
   provider: "openai",
   hostedId: "gpt-4-vision-preview",
   platformLink: OPENAI_PLATORM_LINK,
-  imageInput: true
+  imageInput: true,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 10
+  }
 }
 
 // GPT-4 (UPDATED 1/29/24)
@@ -31,7 +42,13 @@ const GPT4: LLM = {
   provider: "openai",
   hostedId: "gpt-4",
   platformLink: OPENAI_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 30,
+    outputCost: 60
+  }
 }
 
 // GPT-3.5 Turbo (UPDATED 1/25/24)
@@ -41,7 +58,13 @@ const GPT3_5Turbo: LLM = {
   provider: "openai",
   hostedId: "gpt-3.5-turbo",
   platformLink: OPENAI_PLATORM_LINK,
-  imageInput: false
+  imageInput: false,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.5,
+    outputCost: 1.5
+  }
 }
 
 export const OPENAI_LLM_LIST: LLM[] = [GPT4Turbo, GPT4Vision, GPT4, GPT3_5Turbo]

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -6,7 +6,7 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+export type Database = {
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -77,7 +77,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       assistant_files: {
@@ -123,7 +123,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       assistant_tools: {
@@ -169,7 +169,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       assistant_workspaces: {
@@ -215,7 +215,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       assistants: {
@@ -287,7 +287,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       chat_files: {
@@ -333,7 +333,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       chats: {
@@ -419,7 +419,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       collection_files: {
@@ -465,7 +465,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       collection_workspaces: {
@@ -511,7 +511,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       collections: {
@@ -559,7 +559,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       file_items: {
@@ -568,7 +568,6 @@ export interface Database {
           created_at: string
           file_id: string
           id: string
-          level: number | null
           local_embedding: string | null
           openai_embedding: string | null
           sharing: string
@@ -581,7 +580,6 @@ export interface Database {
           created_at?: string
           file_id: string
           id?: string
-          level?: number | null
           local_embedding?: string | null
           openai_embedding?: string | null
           sharing?: string
@@ -594,7 +592,6 @@ export interface Database {
           created_at?: string
           file_id?: string
           id?: string
-          level?: number | null
           local_embedding?: string | null
           openai_embedding?: string | null
           sharing?: string
@@ -616,7 +613,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       file_workspaces: {
@@ -662,7 +659,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       files: {
@@ -722,37 +719,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
-        ]
-      }
-      files_raptor: {
-        Row: {
-          child_chunk_id: string
-          parent_chunk_id: string
-        }
-        Insert: {
-          child_chunk_id: string
-          parent_chunk_id: string
-        }
-        Update: {
-          child_chunk_id?: string
-          parent_chunk_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "files_raptor_child_chunk_id_fkey"
-            columns: ["child_chunk_id"]
-            isOneToOne: false
-            referencedRelation: "file_items"
-            referencedColumns: ["id"]
           },
-          {
-            foreignKeyName: "files_raptor_parent_chunk_id_fkey"
-            columns: ["parent_chunk_id"]
-            isOneToOne: false
-            referencedRelation: "file_items"
-            referencedColumns: ["id"]
-          }
         ]
       }
       folders: {
@@ -800,7 +767,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       message_file_items: {
@@ -846,7 +813,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       messages: {
@@ -910,7 +877,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       model_workspaces: {
@@ -956,7 +923,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       models: {
@@ -1016,7 +983,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       preset_workspaces: {
@@ -1062,7 +1029,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       presets: {
@@ -1131,7 +1098,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       profiles: {
@@ -1226,7 +1193,7 @@ export interface Database {
             isOneToOne: true
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       prompt_workspaces: {
@@ -1272,7 +1239,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       prompts: {
@@ -1320,7 +1287,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       tool_workspaces: {
@@ -1366,7 +1333,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "workspaces"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       tools: {
@@ -1423,7 +1390,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       workspaces: {
@@ -1491,7 +1458,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
     }
@@ -1700,7 +1667,7 @@ export interface Database {
             isOneToOne: false
             referencedRelation: "buckets"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
     }
@@ -1733,7 +1700,7 @@ export interface Database {
         Args: {
           name: string
         }
-        Returns: unknown
+        Returns: string[]
       }
       get_size_by_bucket: {
         Args: Record<PropertyKey, never>
@@ -1772,14 +1739,16 @@ export interface Database {
   }
 }
 
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
         Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
       Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
@@ -1787,68 +1756,68 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
-      Database["public"]["Views"])
-  ? (Database["public"]["Tables"] &
-      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
-      Row: infer R
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof Database["public"]["Tables"]
+    | keyof PublicSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
   ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
-  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof Database["public"]["Enums"]
+    | keyof PublicSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
-  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
-  : never
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
 

--- a/types/llms.ts
+++ b/types/llms.ts
@@ -31,9 +31,9 @@ export type AnthropicLLMID =
 // Mistral Models
 export type MistralLLMID =
   | "mistral-tiny" // Mistral Tiny
-  | "mistral-small" // Mistral Small
-  | "mistral-medium" // Mistral Medium
-  | "mistral-large-2402" // Mistral Large
+  | "mistral-small-latest" // Mistral Small
+  | "mistral-medium-latest" // Mistral Medium
+  | "mistral-large-latest" // Mistral Large
 
 export type GroqLLMID =
   | "llama2-70b-4096" // LLaMA2-70b
@@ -62,6 +62,12 @@ export interface LLM {
   hostedId: string
   platformLink: string
   imageInput: boolean
+  pricing?: {
+    currency: string
+    unit: string
+    inputCost: number
+    outputCost?: number
+  }
 }
 
 export interface OpenRouterLLM extends LLM {


### PR DESCRIPTION
# New Feature: Show Pricing for each hosted Model API.

## Usage
When selecting a Model, the user is able to see the costs of each model by hovering over the model icon/name

<img width="318" alt="image" src="https://github.com/mckaywrigley/chatbot-ui/assets/37416552/e77a61f9-fe71-458d-a8aa-6622a88cf25c">

## List of Models with Pricing Tag
### Anthropic
- Claude 2.1
- Claude 2 Instant
- Claude 3 Haiku
- Claude 3 Sonnet
- Claude 3 Opus

### Groq
- Llama2 70B
- Mixtral 8x7B

### Mistral
- Mistral Small
- Mistral Medium
- Mistral Large

### OpenAI
- GPT-4 Turbo
- GPT-4 Vision (input cost only)
- GPT-4
- GPT-3.5 Turbo

## Variables
- `currency` model billing currency
- `unit` Number of token 
- `inputCost` pricing per `unit` Input Token
- `outoutCost` pricing per `unit` Output Token