### PR TITLE
Fix: Prevent Message Send on Enter in Mobile Mode for Chat Input

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -20,7 +20,7 @@ import { useChatHandler } from "./chat-hooks/use-chat-handler"
 import { useChatHistoryHandler } from "./chat-hooks/use-chat-history"
 import { usePromptAndCommand } from "./chat-hooks/use-prompt-and-command"
 import { useSelectFileHandler } from "./chat-hooks/use-select-file-handler"
-
+const isMobileDevice = () => /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 interface ChatInputProps {}
 
 export const ChatInput: FC<ChatInputProps> = ({}) => {
@@ -79,10 +79,10 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
     setTimeout(() => {
       handleFocusChatInput()
     }, 200) // FIX: hacky
-  }, [selectedPreset, selectedAssistant])
+  }, [selectedPreset, selectedAssistant, handleFocusChatInput])
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (!isTyping && event.key === "Enter" && !event.shiftKey) {
+    if (!isTyping && event.key === "Enter" && !event.shiftKey && !isMobileDevice()) {
       event.preventDefault()
       setIsPromptPickerOpen(false)
       handleSendMessage(userInput, chatMessages, false)


### PR DESCRIPTION
Problem:
Users reported an issue in mobile mode where pressing the Enter key in the chat input box would immediately send the message, preventing them from inserting line breaks into their messages. This behavior diverged from the expected functionality, where users should be able to create new lines within their messages before deciding to send them.

Solution:
This PR introduces a fix to the handleKeyDown event handler within the ChatInput component. By utilizing a utility function, isMobileDevice, we now conditionally prevent the chat message from being sent when the Enter key is pressed without the Shift key on mobile devices. This allows users to insert line breaks as needed. The message will only be sent when the user explicitly chooses to send it, improving the overall user experience in mobile mode.

Changes Made:
Added a utility function isMobileDevice to detect if the application is being accessed from a mobile device. Modified the handleKeyDown function in components/chat/chat-input.tsx to check for mobile devices using the isMobileDevice function. If the device is mobile, pressing Enter inserts a line break instead of sending the message.

Impact:
Improves user experience by allowing for multiline messages in mobile mode. Aligns the behavior of the chat input box with user expectations across devices. This fix ensures that our chat functionality is more intuitive and user-friendly, especially for those accessing the application on mobile devices.