### PR TITLE
Add Discord badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chatbot UI
 
+[![Community Discord](https://dcbadge.vercel.app/api/server/bQeGME3U?style=flat)](https://discord.gg/bQeGME3U)
+
 The open-source AI chat app for everyone.
 
 <img src="./public/readme/screenshot.png" alt="Chatbot UI" width="600">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chatbot UI
 
-[![Community Discord](https://dcbadge.vercel.app/api/server/bQeGME3U?style=flat)](https://discord.gg/bQeGME3U)
+[![Community Discord](https://dcbadge.vercel.app/api/server/bm89NuxyHX?style=flat)](https://discord.gg/bm89NuxyHX)
 
 The open-source AI chat app for everyone.
 


### PR DESCRIPTION
This adds a badge to the Readme, linked to the [Community Discord server](https://github.com/mckaywrigley/chatbot-ui/discussions/1540) created by @Jonneal3.

I used an alternative invite ID, set to not expire.