### PR TITLE
Remove Groq Llama2 and add Llama3 8b model

### DIFF
--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -81,11 +81,11 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
   },
 
   // GROQ MODELS
-  "llama2-70b-4096": {
+  "llama3-8b-8192": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,
-    MAX_TOKEN_OUTPUT_LENGTH: 4096,
-    MAX_CONTEXT_LENGTH: 4096
+    MAX_TOKEN_OUTPUT_LENGTH: 8192,
+    MAX_CONTEXT_LENGTH: 8192
   },
   "llama3-70b-8192": {
     MIN_TEMPERATURE: 0.0,

--- a/lib/models/llm/groq-llm-list.ts
+++ b/lib/models/llm/groq-llm-list.ts
@@ -2,18 +2,18 @@ import { LLM } from "@/types"
 
 const GROQ_PLATORM_LINK = "https://groq.com/"
 
-const LLaMA2_70B: LLM = {
-  modelId: "llama2-70b-4096",
-  modelName: "LLaMA2-70b-chat",
+const LLaMA3_8B: LLM = {
+  modelId: "llama3-8b-8192",
+  modelName: "LLaMA3-8b-chat",
   provider: "groq",
-  hostedId: "llama2-70b-4096",
+  hostedId: "llama3-8b-8192",
   platformLink: GROQ_PLATORM_LINK,
   imageInput: false,
   pricing: {
     currency: "USD",
     unit: "1M tokens",
-    inputCost: 0.7,
-    outputCost: 0.8
+    inputCost: 0.05,
+    outputCost: 0.10
   }
 }
 
@@ -47,4 +47,4 @@ const MIXTRAL_8X7B: LLM = {
   }
 }
 
-export const GROQ_LLM_LIST: LLM[] = [LLaMA2_70B, LLaMA3_70B, MIXTRAL_8X7B]
+export const GROQ_LLM_LIST: LLM[] = [LLaMA3_8B, LLaMA3_70B, MIXTRAL_8X7B]

--- a/types/llms.ts
+++ b/types/llms.ts
@@ -36,7 +36,7 @@ export type MistralLLMID =
   | "mistral-large-latest" // Mistral Large
 
 export type GroqLLMID =
-  | "llama2-70b-4096" // LLaMA2-70b
+  | "llama3-8b-8192" // LLaMA3-8b
   | "llama3-70b-8192" // LLaMA3-70b
   | "mixtral-8x7b-32768" // Mixtral-8x7b
 


### PR DESCRIPTION
Groq removed the Llama 2 model

![image](https://github.com/mckaywrigley/chatbot-ui/assets/113581962/679e1516-17b0-439c-893a-80c15a518fab)

replacing it with the Llama 3 8b model
