### PR TITLE
Fix image_url parameter to match recent OpenAI Docs

### DIFF
--- a/app/api/chat/anthropic/route.ts
+++ b/app/api/chat/anthropic/route.ts
@@ -37,14 +37,14 @@ export async function POST(request: NextRequest) {
               return { type: "text", text: content }
             } else if (
               content?.type === "image_url" &&
-              content?.image_url?.length
+              content?.image_url?.url?.length
             ) {
               return {
                 type: "image",
                 source: {
                   type: "base64",
-                  media_type: getMediaTypeFromDataURL(content.image_url),
-                  data: getBase64FromDataURL(content.image_url)
+                  media_type: getMediaTypeFromDataURL(content.image_url.url),
+                  data: getBase64FromDataURL(content.image_url.url)
                 }
               }
             } else {

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -28,7 +28,11 @@ export async function POST(request: Request) {
       model: chatSettings.model as ChatCompletionCreateParamsBase["model"],
       messages: messages as ChatCompletionCreateParamsBase["messages"],
       temperature: chatSettings.temperature,
-      max_tokens: chatSettings.model === "gpt-4-vision-preview" ? 4096 : null, // TODO: Fix
+      max_tokens:
+        chatSettings.model === "gpt-4-vision-preview" ||
+        chatSettings.model === "gpt-4o"
+          ? 4096
+          : null, // TODO: Fix
       stream: true
     })
 

--- a/lib/build-prompt.ts
+++ b/lib/build-prompt.ts
@@ -144,7 +144,9 @@ export async function buildFinalMessages(
 
           return {
             type: "image_url",
-            image_url: formedUrl
+            image_url: {
+              url: formedUrl
+            }
           }
         })
       ]


### PR DESCRIPTION
According to the recent OpenAI docs, `image_url` must be passed the following way to vision models:

```
{
  "type": "image_url",
  "image_url": {
    "url": f"data:image/jpeg;base64,{base64_image}"
  }
}
```

See here: https://platform.openai.com/docs/guides/vision/uploading-base-64-encoded-images

I also changed the Claude API route to avoid breaking existing vision models.

I have no access to Gemini Pro Vision, so that is the only vision model I could not test.