### PR TITLE
Add GPT-4o for Azure OpenAI

### DIFF
--- a/app/api/chat/azure/route.ts
+++ b/app/api/chat/azure/route.ts
@@ -23,6 +23,9 @@ export async function POST(request: Request) {
       case "gpt-3.5-turbo":
         DEPLOYMENT_ID = profile.azure_openai_35_turbo_id || ""
         break
+      case "gpt-4o":
+        DEPLOYMENT_ID = profile.azure_openai_45_o_id || ""
+        break
       case "gpt-4-turbo-preview":
         DEPLOYMENT_ID = profile.azure_openai_45_turbo_id || ""
         break

--- a/components/utility/profile-settings.tsx
+++ b/components/utility/profile-settings.tsx
@@ -91,6 +91,9 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
   const [azureOpenai35TurboID, setAzureOpenai35TurboID] = useState(
     profile?.azure_openai_35_turbo_id || ""
   )
+  const [azureOpenai45OID, setAzureOpenai45OID] = useState(
+    profile?.azure_openai_45_o_id || ""
+  )
   const [azureOpenai45TurboID, setAzureOpenai45TurboID] = useState(
     profile?.azure_openai_45_turbo_id || ""
   )
@@ -154,6 +157,7 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
       azure_openai_api_key: azureOpenaiAPIKey,
       azure_openai_endpoint: azureOpenaiEndpoint,
       azure_openai_35_turbo_id: azureOpenai35TurboID,
+      azure_openai_45_o_id: azureOpenai45OID,
       azure_openai_45_turbo_id: azureOpenai45TurboID,
       azure_openai_45_vision_id: azureOpenai45VisionID,
       azure_openai_embeddings_id: azureEmbeddingsID,
@@ -528,6 +532,28 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
                               value={azureOpenai35TurboID}
                               onChange={e =>
                                 setAzureOpenai35TurboID(e.target.value)
+                              }
+                            />
+                          </>
+                        )}
+                      </div>
+                    }
+
+                    {
+                      <div className="space-y-1">
+                        {envKeyMap["azure_gpt_45_o_name"] ? (
+                          <Label className="text-xs">
+                            Azure GPT-4.5 O deployment name set by admin.
+                          </Label>
+                        ) : (
+                          <>
+                            <Label>Azure GPT-4.5 O Deployment Name</Label>
+
+                            <Input
+                              placeholder="Azure GPT-4.5 O Deployment Name"
+                              value={azureOpenai45OID}
+                              onChange={e =>
+                                setAzureOpenai45OID(e.target.value)
                               }
                             />
                           </>

--- a/supabase/migrations/20240526065246_add_azure_openai_45_o_id_to_profiles.sql
+++ b/supabase/migrations/20240526065246_add_azure_openai_45_o_id_to_profiles.sql
@@ -1,0 +1,3 @@
+alter table "public"."profiles" add column "azure_openai_45_o_id" text default ''::text;
+
+

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1105,6 +1105,7 @@ export type Database = {
         Row: {
           anthropic_api_key: string | null
           azure_openai_35_turbo_id: string | null
+          azure_openai_45_o_id: string | null
           azure_openai_45_turbo_id: string | null
           azure_openai_45_vision_id: string | null
           azure_openai_api_key: string | null
@@ -1133,6 +1134,7 @@ export type Database = {
         Insert: {
           anthropic_api_key?: string | null
           azure_openai_35_turbo_id?: string | null
+          azure_openai_45_o_id?: string | null
           azure_openai_45_turbo_id?: string | null
           azure_openai_45_vision_id?: string | null
           azure_openai_api_key?: string | null
@@ -1161,6 +1163,7 @@ export type Database = {
         Update: {
           anthropic_api_key?: string | null
           azure_openai_35_turbo_id?: string | null
+          azure_openai_45_o_id?: string | null
           azure_openai_45_turbo_id?: string | null
           azure_openai_45_vision_id?: string | null
           azure_openai_api_key?: string | null


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 690f94ca55b529aa3ee920b9206cfbad0c604e7d  | 
|--------|

### Summary:
This PR integrates GPT-4o model support into the Azure OpenAI API configuration, including backend, frontend, and database updates.

**Key points**:
- Added `gpt-4o` case in `POST` function in `app/api/chat/azure/route.ts` to handle new model.
- Added new state `azureOpenai45OID` in `ProfileSettings` component in `components/utility/profile-settings.tsx` for frontend configuration.
- Added new database column `azure_openai_45_o_id` in `profiles` table via migration in `supabase/migrations/20240526065246_add_azure_openai_45_o_id_to_profiles.sql`.
- Updated `Database` type in `supabase/types.ts` to include new column.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
