### PR TITLE
Remove clear-user-input after response

### DIFF
--- a/components/chat/chat-hooks/use-chat-handler.tsx
+++ b/components/chat/chat-hooks/use-chat-handler.tsx
@@ -382,7 +382,6 @@ export const useChatHandler = () => {
 
       setIsGenerating(false)
       setFirstTokenReceived(false)
-      setUserInput("")
     } catch (error) {
       setIsGenerating(false)
       setFirstTokenReceived(false)


### PR DESCRIPTION
Fixes mckaywrigley/chatbot-ui#1683, mckaywrigley/chatbot-ui#1709

https://github.com/mckaywrigley/chatbot-ui/assets/42156028/a3bed5df-cdce-454e-8d24-338f0f0973d0



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0f3f68d54d9ec998b3ba958424c2577d7b363b5e  | 
|--------|

### Summary:
Modified `useChatHandler` in `use-chat-handler.tsx` to retain user input after chat responses or errors by removing `setUserInput("")`.

**Key points**:
- Removed `setUserInput("")` from `useChatHandler` in `use-chat-handler.tsx` to prevent clearing user input after responses or errors.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
