### PR TITLE
Only strip file extension if a file has one

### DIFF
--- a/db/files.ts
+++ b/db/files.ts
@@ -93,7 +93,8 @@ export const createFile = async (
 ) => {
   let validFilename = fileRecord.name.replace(/[^a-z0-9.]/gi, "_").toLowerCase()
   const extension = file.name.split(".").pop()
-  const baseName = validFilename.substring(0, validFilename.lastIndexOf("."))
+  const extensionIndex = validFilename.lastIndexOf(".")
+  const baseName = validFilename.substring(0, (extensionIndex < 0) ? undefined : extensionIndex)
   const maxBaseNameLength = 100 - (extension?.length || 0) - 1
   if (baseName.length > maxBaseNameLength) {
     fileRecord.name = baseName.substring(0, maxBaseNameLength) + "." + extension


### PR DESCRIPTION
Fixes #1734

When a filename lacks an extension, the entire base filename is removed. When files are uploaded through the sidebar's 'New Files' button, the extension is already stripped from the filename. However, uploading files directly via the chat retains the extension. This change enables both scenarios to function while preserving the base filename.


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 43d56bb18200542cff60d6c3630dfa2251e71ed8  | 
|--------|

### Summary:
This PR updates the `createFile` function to correctly handle filenames with and without extensions, fixing a bug where filenames without extensions were incorrectly stripped.

**Key points**:
- Updated `createFile` function in `db/files.ts` to handle filenames with and without extensions.
- Introduced a check for the presence of a file extension before stripping it.
- Fixes issue where filenames without extensions were incorrectly processed, preserving the base filename.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
