### PR TITLE
Add Google Gemini Flash, @google/generative-ai version update to 0.11.4 , cleanup Gemini message hacks

### DIFF
--- a/app/api/chat/google/route.ts
+++ b/app/api/chat/google/route.ts
@@ -19,49 +19,32 @@ export async function POST(request: Request) {
     const genAI = new GoogleGenerativeAI(profile.google_gemini_api_key || "")
     const googleModel = genAI.getGenerativeModel({ model: chatSettings.model })
 
-    if (chatSettings.model === "gemini-pro") {
-      const lastMessage = messages.pop()
+    const lastMessage = messages.pop()
 
-      const chat = googleModel.startChat({
-        history: messages,
-        generationConfig: {
-          temperature: chatSettings.temperature
+    const chat = googleModel.startChat({
+      history: messages,
+      generationConfig: {
+        temperature: chatSettings.temperature
+      }
+    })
+
+    const response = await chat.sendMessageStream(lastMessage.parts)
+
+    const encoder = new TextEncoder()
+    const readableStream = new ReadableStream({
+      async start(controller) {
+        for await (const chunk of response.stream) {
+          const chunkText = chunk.text()
+          controller.enqueue(encoder.encode(chunkText))
         }
-      })
+        controller.close()
+      }
+    })
 
-      const response = await chat.sendMessageStream(lastMessage.parts)
+    return new Response(readableStream, {
+      headers: { "Content-Type": "text/plain" }
+    })
 
-      const encoder = new TextEncoder()
-      const readableStream = new ReadableStream({
-        async start(controller) {
-          for await (const chunk of response.stream) {
-            const chunkText = chunk.text()
-            controller.enqueue(encoder.encode(chunkText))
-          }
-          controller.close()
-        }
-      })
-
-      return new Response(readableStream, {
-        headers: { "Content-Type": "text/plain" }
-      })
-    } else if (chatSettings.model === "gemini-pro-vision") {
-      // FIX: Hacky until chat messages are supported
-      const HACKY_MESSAGE = messages[messages.length - 1]
-
-      const result = await googleModel.generateContent([
-        HACKY_MESSAGE.prompt,
-        HACKY_MESSAGE.imageParts
-      ])
-
-      const response = result.response
-
-      const text = response.text()
-
-      return new Response(text, {
-        headers: { "Content-Type": "text/plain" }
-      })
-    }
   } catch (error: any) {
     let errorMessage = error.message || "An unexpected error occurred"
     const errorCode = error.status || 500

--- a/components/chat/chat-helpers/index.ts
+++ b/components/chat/chat-helpers/index.ts
@@ -7,7 +7,7 @@ import { createMessages, updateMessage } from "@/db/messages"
 import { uploadMessageImage } from "@/db/storage/message-images"
 import {
   buildFinalMessages,
-  buildGoogleGeminiFinalMessages
+  adaptMessagesForGoogleGemini
 } from "@/lib/build-prompt"
 import { consumeReadableStream } from "@/lib/consume-stream"
 import { Tables, TablesInsert } from "@/supabase/types"
@@ -206,16 +206,13 @@ export const handleHostedChat = async (
       ? "azure"
       : modelData.provider
 
-  let formattedMessages = []
+  let draftMessages = await buildFinalMessages(payload, profile, chatImages)
 
+  let formattedMessages : any[] = []
   if (provider === "google") {
-    formattedMessages = await buildGoogleGeminiFinalMessages(
-      payload,
-      profile,
-      newMessageImages
-    )
+    formattedMessages = await adaptMessagesForGoogleGemini(payload, draftMessages)
   } else {
-    formattedMessages = await buildFinalMessages(payload, profile, chatImages)
+    formattedMessages = draftMessages
   }
 
   const apiEndpoint =

--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -41,6 +41,12 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
   },
 
   // GOOGLE MODELS
+  "gemini-1.5-pro-latest": {
+    MIN_TEMPERATURE: 0.0,
+    MAX_TEMPERATURE: 1.0,
+    MAX_TOKEN_OUTPUT_LENGTH: 8192,
+    MAX_CONTEXT_LENGTH: 1040384
+  },
   "gemini-pro": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,

--- a/lib/models/llm/google-llm-list.ts
+++ b/lib/models/llm/google-llm-list.ts
@@ -4,6 +4,16 @@ const GOOGLE_PLATORM_LINK = "https://ai.google.dev/"
 
 // Google Models (UPDATED 12/22/23) -----------------------------
 
+// Gemini Flash (UPDATED 05/28/24)
+const GEMINI_FLASH: LLM = {
+  modelId: "gemini-1.5-pro-latest",
+  modelName: "Gemini Flash",
+  provider: "google",
+  hostedId: "gemini-1.5-pro-latest",
+  platformLink: GOOGLE_PLATORM_LINK,
+  imageInput: false
+}
+
 // Gemini Pro (UPDATED 12/22/23)
 const GEMINI_PRO: LLM = {
   modelId: "gemini-pro",
@@ -24,4 +34,4 @@ const GEMINI_PRO_VISION: LLM = {
   imageInput: true
 }
 
-export const GOOGLE_LLM_LIST: LLM[] = [GEMINI_PRO, GEMINI_PRO_VISION]
+export const GOOGLE_LLM_LIST: LLM[] = [GEMINI_PRO, GEMINI_PRO_VISION, GEMINI_FLASH]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.18.0",
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
         "@azure/openai": "^1.0.0-beta.8",
-        "@google/generative-ai": "^0.1.3",
+        "@google/generative-ai": "^0.11.4",
         "@hookform/resolvers": "^3.3.2",
         "@mistralai/mistralai": "^0.0.8",
         "@radix-ui/react-accordion": "^1.1.2",
@@ -2219,9 +2219,9 @@
       }
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.1.3.tgz",
-      "integrity": "sha512-Cm4uJX1sKarpm1mje/MiOIinM7zdUUrQp/5/qGPAgznbdd/B9zup5ehT6c1qGqycFcSopTA1J1HpqHS5kJR8hQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.11.4.tgz",
+      "integrity": "sha512-hlw+E9Prv9aUIQISRnLSXi4rukFqKe5WhxPvzBccTvIvXjw2BHMFOJWSC/Gq7WE0W+L/qRHGmYxopmx9qjrB9w==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@anthropic-ai/sdk": "^0.18.0",
     "@apidevtools/json-schema-ref-parser": "^11.1.0",
     "@azure/openai": "^1.0.0-beta.8",
-    "@google/generative-ai": "^0.1.3",
+    "@google/generative-ai": "^0.11.4",
     "@hookform/resolvers": "^3.3.2",
     "@mistralai/mistralai": "^0.0.8",
     "@radix-ui/react-accordion": "^1.1.2",

--- a/types/llms.ts
+++ b/types/llms.ts
@@ -20,6 +20,7 @@ export type OpenAILLMID =
 export type GoogleLLMID =
   | "gemini-pro" // Gemini Pro
   | "gemini-pro-vision" // Gemini Pro Vision
+  | "gemini-1.5-pro-latest"
 
 // Anthropic Models
 export type AnthropicLLMID =


### PR DESCRIPTION
This PR:

- adds Gemini Flash (gemini-1.5-pro-latest)
- increases @google/generative-ai NPM package version from 0.1.3 to 0.11.4
- adapts to @google/generative-ai changes since 0.1.3 (use of **parts** under content and part type requirement)
- simplifies Gemini messages to be adapted from final messages, instead of created independently from scratch 
- simplifies Gemini Vision hacky single message query (required, it's not a multi-message endpoint on Google side)
- a bit of cleanup after simplification of Gemini message and Gemini Vision related code

@mckaywrigley I've tested this, Gemini Pro, Gemini Flash and Gemini Vision works as designed.

Since Gemini Vision is already working on Google's side as an endpoint working with a single message, I focused to simplify it to process the last message from user inside the session. Otherwise, taking it all prompts and all image data would be snowballing into too much cost and Gemini Vision endpoint might not understand the context at all when images are completely unrelated.

At this point, Gemini Flash is the best multi-message model. Google Vision has lower guardrails so it still has a place I guess.

It'd be great if you try it and tell me what you think.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2d21ee2fdad6a112e1a019b31a5d0d3051a77ed3  | 
|--------|--------|

### Summary:
This PR adds support for the Gemini Flash model, updates the @google/generative-ai package, and refactors Gemini message handling for simplicity and efficiency.

**Key points**:
- Adds `Gemini Flash` model support.
- Updates `@google/generative-ai` package from `0.1.3` to `0.11.4`.
- Adapts message handling to updated `@google/generative-ai` package requirements.
- Simplifies Gemini message handling by adapting from final messages.
- Simplifies Gemini Vision message handling for single message endpoint.
- Cleans up code post-refactoring.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
