### PR TITLE
fix google model name and add gemini 1.5 flash

### DIFF
--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -41,6 +41,13 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
   },
 
   // GOOGLE MODELS
+  
+  "gemini-1.5-flash": {
+    MIN_TEMPERATURE: 0.0,
+    MAX_TEMPERATURE: 1.0,
+    MAX_TOKEN_OUTPUT_LENGTH: 8192,
+    MAX_CONTEXT_LENGTH: 1040384
+  },
   "gemini-1.5-pro-latest": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 1.0,

--- a/lib/models/llm/google-llm-list.ts
+++ b/lib/models/llm/google-llm-list.ts
@@ -4,14 +4,24 @@ const GOOGLE_PLATORM_LINK = "https://ai.google.dev/"
 
 // Google Models (UPDATED 12/22/23) -----------------------------
 
-// Gemini Flash (UPDATED 05/28/24)
-const GEMINI_FLASH: LLM = {
+// Gemini 1.5 Flash
+const GEMINI_1_5_FLASH: LLM = {
+  modelId: "gemini-1.5-flash",
+  modelName: "Gemini 1.5 Flash",
+  provider: "google",
+  hostedId: "gemini-1.5-flash",
+  platformLink: GOOGLE_PLATORM_LINK,
+  imageInput: true
+}
+
+// Gemini 1.5 Pro (UPDATED 05/28/24)
+const GEMINI_1_5_PRO: LLM = {
   modelId: "gemini-1.5-pro-latest",
-  modelName: "Gemini Flash",
+  modelName: "Gemini 1.5 Pro",
   provider: "google",
   hostedId: "gemini-1.5-pro-latest",
   platformLink: GOOGLE_PLATORM_LINK,
-  imageInput: false
+  imageInput: true
 }
 
 // Gemini Pro (UPDATED 12/22/23)
@@ -34,4 +44,4 @@ const GEMINI_PRO_VISION: LLM = {
   imageInput: true
 }
 
-export const GOOGLE_LLM_LIST: LLM[] = [GEMINI_PRO, GEMINI_PRO_VISION, GEMINI_FLASH]
+export const GOOGLE_LLM_LIST: LLM[] = [GEMINI_PRO, GEMINI_PRO_VISION, GEMINI_1_5_PRO, GEMINI_1_5_FLASH]

--- a/types/llms.ts
+++ b/types/llms.ts
@@ -20,7 +20,8 @@ export type OpenAILLMID =
 export type GoogleLLMID =
   | "gemini-pro" // Gemini Pro
   | "gemini-pro-vision" // Gemini Pro Vision
-  | "gemini-1.5-pro-latest"
+  | "gemini-1.5-pro-latest" // Gemini 1.5 Pro
+  | "gemini-1.5-flash" // Gemini 1.5 Flash
 
 // Anthropic Models
 export type AnthropicLLMID =


### PR DESCRIPTION
This PR includes the following changes:

1. Rename "Gemini Flash" to "Gemini 1.5 Pro" because the model name used is "Gemini 1.5 Pro," but it is currently named "Gemini Flash."
2. I made the 'imageInput' property true, as 'Gemini 1.5 Pro' supports image input.
3. Add "Gemini 1.5 Flash" with the correct model ID and name. It is similar to "Gemini 1.5 Pro" but faster in comparison.
<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 04c42ba1bc0bffca63f1e1dacf54cb85a6de5e3a  | 
|--------|--------|

### Summary:
This PR renames 'Gemini Flash' to 'Gemini 1.5 Pro', updates its image input capability, and adds a new model 'Gemini 1.5 Flash' with appropriate settings and type definitions.

**Key points**:
- Rename `Gemini Flash` to `Gemini 1.5 Pro` in `lib/models/llm/google-llm-list.ts`.
- Update `imageInput` to `true` for `Gemini 1.5 Pro`.
- Add `Gemini 1.5 Flash` with settings in `lib/chat-setting-limits.ts` and `lib/models/llm/google-llm-list.ts`.
- Update `types/llms.ts` to include `gemini-1.5-flash`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->