### PR TITLE
Disable safety checking for Gemini

### DIFF
--- a/app/api/chat/google/route.ts
+++ b/app/api/chat/google/route.ts
@@ -1,6 +1,11 @@
 import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
 import { ChatSettings } from "@/types"
-import { GoogleGenerativeAI } from "@google/generative-ai"
+import {
+  GoogleGenerativeAI,
+  HarmBlockThreshold,
+  HarmCategory,
+  SafetySetting
+} from "@google/generative-ai"
 
 export const runtime = "edge"
 
@@ -17,7 +22,30 @@ export async function POST(request: Request) {
     checkApiKey(profile.google_gemini_api_key, "Google")
 
     const genAI = new GoogleGenerativeAI(profile.google_gemini_api_key || "")
-    const googleModel = genAI.getGenerativeModel({ model: chatSettings.model })
+
+    const safety: SafetySetting[] = [
+      {
+        category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold: HarmBlockThreshold.BLOCK_NONE
+      },
+      {
+        category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        threshold: HarmBlockThreshold.BLOCK_NONE
+      },
+      {
+        category: HarmCategory.HARM_CATEGORY_HARASSMENT,
+        threshold: HarmBlockThreshold.BLOCK_NONE
+      },
+      {
+        category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        threshold: HarmBlockThreshold.BLOCK_NONE
+      }
+    ]
+
+    const googleModel = genAI.getGenerativeModel({
+      model: chatSettings.model,
+      safetySettings: safety
+    })
 
     const lastMessage = messages.pop()
 


### PR DESCRIPTION
Gemini is quite over-zealous with the default safety settings, triggering on completely benign tasks.
Ideally, we should make this configurable, but until someone implements it, let's just set the safety thresholds to the max.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e99388916d0e2459c795be75bb3bc9bd40f97167  | 
|--------|--------|

### Summary:
This PR updates the `POST` function in `app/api/chat/google/route.ts` to disable safety checks by setting all harm block thresholds to `BLOCK_NONE` for the Google Generative AI model.

**Key points**:
- Updated `POST` function in `app/api/chat/google/route.ts`
- Imported `HarmBlockThreshold`, `HarmCategory`, `SafetySetting` from `@google/generative-ai`
- Set all safety thresholds to `BLOCK_NONE` for various categories
- Configured `GoogleGenerativeAI` model with new safety settings


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->