### PR TITLE
Bugfix: key can be caps when shift pressed

### DIFF
--- a/lib/hooks/use-hotkey.tsx
+++ b/lib/hooks/use-hotkey.tsx
@@ -3,7 +3,11 @@ import { useEffect } from "react"
 const useHotkey = (key: string, callback: () => void): void => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.metaKey && event.shiftKey && event.key === key) {
+      if (
+        event.metaKey &&
+        event.shiftKey &&
+        event.key.toLowerCase() === key.toLowerCase()
+      ) {
         event.preventDefault()
         callback()
       }


### PR DESCRIPTION
Compares key pressed for hotkeys **after converting to lowercase**.  Key pressed was received as Caps on my setup

Browser: Chrome
OS: Windows

 Since hotkey requires `shift` to be pressed the key pressed is interpreted as caps. Example, `cmd+shift+o` -> key: `O` 