### PR TITLE
Muted color normalized

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -66,7 +66,7 @@
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
 
-    --muted: 0 0% 14.9%;
+    --muted: 0 0% 9.5%;
     --muted-foreground: 0 0% 63.9%;
 
     --popover: 0 0% 3.9%;

--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -33,7 +33,7 @@
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
 
-    --muted: 0 0% 96.1%;
+    --muted: 0 0% 96.5%;
     --muted-foreground: 0 0% 45.1%;
 
     --popover: 0 0% 100%;

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -211,7 +211,7 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
         )}
       </div>
 
-      <div className="border-input relative mt-3 flex min-h-[60px] w-full items-center justify-center rounded-xl border-2">
+      <div className="border-input bg-muted relative mt-3 flex min-h-[60px] w-full items-center justify-center rounded-xl border-2">
         <div className="absolute bottom-[76px] left-0 max-h-[300px] w-full overflow-auto rounded-xl dark:border-none">
           <ChatCommandInput />
         </div>
@@ -238,7 +238,7 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
 
         <TextareaAutosize
           textareaRef={chatInputRef}
-          className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md bg-primary-foreground flex w-full resize-none rounded-md border-none px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md flex w-full resize-none rounded-md border-none bg-transparent px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           placeholder={t(
             // `Ask anything. Type "@" for assistants, "/" for prompts, "#" for files, and "!" for tools.`
             `Ask anything. Type @  /  #  !`

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -238,7 +238,7 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
 
         <TextareaAutosize
           textareaRef={chatInputRef}
-          className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md flex w-full resize-none rounded-md border-none bg-transparent px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          className="ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring text-md bg-primary-foreground flex w-full resize-none rounded-md border-none px-14 py-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           placeholder={t(
             // `Ask anything. Type "@" for assistants, "/" for prompts, "#" for files, and "!" for tools.`
             `Ask anything. Type @  /  #  !`

--- a/components/ui/dashboard.tsx
+++ b/components/ui/dashboard.tsx
@@ -99,7 +99,7 @@ export const Dashboard: FC<DashboardProps> = ({ children }) => {
       </div>
 
       <div
-        className="bg-muted/50 relative flex w-screen min-w-[90%] grow flex-col sm:min-w-fit"
+        className="bg-muted relative flex w-screen min-w-[90%] grow flex-col sm:min-w-fit"
         onDrop={onFileDrop}
         onDragOver={onDragOver}
         onDragEnter={handleDragEnter}


### PR DESCRIPTION
I noted that in most places where the `muted` color was used, it was used as `muted/50`. 

This had unintended consequences related to transparency like this one:

![image](https://github.com/mckaywrigley/chatbot-ui/assets/16997807/7f875e64-4158-4ef1-afd5-c12a1ef7c682)
Explanation:
- Window has zoom
- Chat background is `bg-muted/50` 
- Input should have the same color as chat background, but if `bg-muted/50`  is applied, it keeps 50% transparency. 
- Solution: use bg-muted with no transparency for input

### Changes:
- ` bg-muted/50`  replaced by `bg-muted` 
- Adjusted `muted` to have the same color as the previous `muted/50`

Components under `components/ui` still have the `muted/[num]`  classes