### PR TITLE
Ctrl-Enter to Save & Send when editing a prompt

### DIFF
--- a/components/messages/message.tsx
+++ b/components/messages/message.tsx
@@ -98,7 +98,7 @@ export const Message: FC<MessageProps> = ({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (isEditing && event.key === "Enter" && event.metaKey) {
+    if (isEditing && event.key === "Enter" && (event.metaKey || event.ctrlKey) ) {
       handleSendEdit()
     }
   }


### PR DESCRIPTION
Cmd-Enter already works on Mac, this adds Ctrl-Enter which is customary on other platforms.
Closes #1798 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8c4e5de29a4ce3420236ba0ce717051155afdef4  | 
|--------|--------|

### Summary:
Added support for Ctrl-Enter to save and send a message while editing in `components/messages/message.tsx`.

**Key points**:
- **File Modified**: `components/messages/message.tsx`
- **Function Modified**: `Message.handleKeyDown`
- **Change**: Added support for `Ctrl-Enter` to save and send a message while editing, in addition to the existing `Cmd-Enter` functionality on Mac.
- **Behavior**: When editing a message, pressing `Ctrl-Enter` (or `Cmd-Enter` on Mac) will trigger `handleSendEdit`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->