### PR TITLE
added openai gpt4o mini model

### DIFF
--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -30,10 +30,11 @@ export async function POST(request: Request) {
       temperature: chatSettings.temperature,
       max_tokens:
         chatSettings.model === "gpt-4-vision-preview" ||
-        chatSettings.model === "gpt-4o" ||
-        chatSettings.model === "gpt-4o-mini"
+        chatSettings.model === "gpt-4o"
           ? 4096
-          : null, // TODO: Fix
+          : chatSettings.model === "gpt-4o-mini"
+          ? 16383
+          : null, 
       stream: true
     })
 

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -30,7 +30,8 @@ export async function POST(request: Request) {
       temperature: chatSettings.temperature,
       max_tokens:
         chatSettings.model === "gpt-4-vision-preview" ||
-        chatSettings.model === "gpt-4o"
+        chatSettings.model === "gpt-4o" ||
+        chatSettings.model === "gpt-4o-mini"
           ? 4096
           : null, // TODO: Fix
       stream: true

--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -160,7 +160,7 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
   "gpt-4o-mini": {
     MIN_TEMPERATURE: 0.0,
     MAX_TEMPERATURE: 2.0,
-    MAX_TOKEN_OUTPUT_LENGTH: 4096,
+    MAX_TOKEN_OUTPUT_LENGTH: 16383,
     MAX_CONTEXT_LENGTH: 128000
   },
 

--- a/lib/chat-setting-limits.ts
+++ b/lib/chat-setting-limits.ts
@@ -157,6 +157,12 @@ export const CHAT_SETTING_LIMITS: Record<LLMID, ChatSettingLimits> = {
     MAX_TOKEN_OUTPUT_LENGTH: 4096,
     MAX_CONTEXT_LENGTH: 128000
   },
+  "gpt-4o-mini": {
+    MIN_TEMPERATURE: 0.0,
+    MAX_TEMPERATURE: 2.0,
+    MAX_TOKEN_OUTPUT_LENGTH: 4096,
+    MAX_CONTEXT_LENGTH: 128000
+  },
 
   // PERPLEXITY MODELS
   "pplx-7b-online": {

--- a/lib/models/llm/openai-llm-list.ts
+++ b/lib/models/llm/openai-llm-list.ts
@@ -3,6 +3,22 @@ import { LLM } from "@/types"
 const OPENAI_PLATORM_LINK = "https://platform.openai.com/docs/overview"
 
 // OpenAI Models (UPDATED 1/25/24) -----------------------------
+
+const GPT4oMini: LLM = {
+  modelId: "gpt-4o-mini",
+  modelName: "GPT-4o Mini",
+  provider: "openai",
+  hostedId: "gpt-4o-mini",
+  platformLink: OPENAI_PLATORM_LINK,
+  imageInput: true,
+  pricing: {
+    currency: "USD",
+    unit: "1M tokens",
+    inputCost: 0.15,
+    outputCost: 0.6
+  }
+}
+
 const GPT4o: LLM = {
   modelId: "gpt-4o",
   modelName: "GPT-4o",

--- a/lib/models/llm/openai-llm-list.ts
+++ b/lib/models/llm/openai-llm-list.ts
@@ -98,6 +98,7 @@ const GPT3_5Turbo: LLM = {
 }
 
 export const OPENAI_LLM_LIST: LLM[] = [
+  GPT4oMini,
   GPT4o,
   GPT4Turbo,
   GPT4Vision,

--- a/types/llms.ts
+++ b/types/llms.ts
@@ -10,6 +10,7 @@ export type LLMID =
 
 // OpenAI Models (UPDATED 5/13/24)
 export type OpenAILLMID =
+  | "gpt-4o-mini" // GPT-4o Mini
   | "gpt-4o" // GPT-4o
   | "gpt-4-turbo-preview" // GPT-4 Turbo
   | "gpt-4-vision-preview" // GPT-4 Vision


### PR DESCRIPTION
[blog post](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/)
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6256a11620b3288e4539e6aecadc32d92d1e5706  | 
|--------|--------|

### Summary:
Added support for the new OpenAI GPT-4o Mini model, including chat setting limits, model definition, and type updates.

**Key points**:
- Added `gpt-4o-mini` model to `CHAT_SETTING_LIMITS` in `lib/chat-setting-limits.ts` with specific temperature, token output length, and context length limits.
- Added `GPT4oMini` model definition to `lib/models/llm/openai-llm-list.ts` with pricing and other details.
- Updated `OpenAILLMID` type in `types/llms.ts` to include `gpt-4o-mini`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->