### PR TITLE
Improved Image optimization for vercel usage

### DIFF
--- a/components/utility/profile-settings.tsx
+++ b/components/utility/profile-settings.tsx
@@ -299,7 +299,7 @@ export const ProfileSettings: FC<ProfileSettingsProps> = ({}) => {
         {profile.image_url ? (
           <Image
             className="mt-2 size-[34px] cursor-pointer rounded hover:opacity-50"
-            src={profile.image_url + "?" + new Date().getTime()}
+            src={profile.image_url}
             height={34}
             width={34}
             alt={"Image"}

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ module.exports = withBundleAnalyzer(
   withPWA({
     reactStrictMode: true,
     images: {
+      unoptimized: false,
       remotePatterns: [
         {
           protocol: "http",
@@ -22,7 +23,12 @@ module.exports = withBundleAnalyzer(
         {
           protocol: "https",
           hostname: "**"
-        }
+        },
+        {
+          protocol: 'https',
+          hostname: '**.supabase.co',
+          pathname: '/storage/v1/object/public/profile_images/**',
+        },
       ]
     },
     experimental: {


### PR DESCRIPTION
**_Vercel only allows 1000 images a month for image optimization for the hobby plan._**

This merge removes the call made for each profile image that vercel recognized as a "unique" image which subsequently (and significantly) racks up vercels image optimization usage. In a nutshell:

- Removed timestamp from profile image src (that leads to vercel believing that every image src call is unique)
- Added remote patterns for image optimization + flag to turn optimization on/off globally

[Reference](https://vercel.com/docs/image-optimization/managing-image-optimization-costs) 



![image](https://github.com/user-attachments/assets/8032814b-9a7e-4c67-9c50-9a1a15ebf4d9)
