### PR TITLE
Fix OpenAI 403 Forbidden country, region, or territory errors by executing query on Edge Functions located in the US

### DIFF
--- a/app/api/assistants/openai/route.ts
+++ b/app/api/assistants/openai/route.ts
@@ -3,6 +3,7 @@ import { ServerRuntime } from "next"
 import OpenAI from "openai"
 
 export const runtime: ServerRuntime = "edge"
+export const preferredRegion = ["iad1", "cle1", "pdx1", "sfo1"]
 
 export async function GET() {
   try {

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -6,6 +6,7 @@ import OpenAI from "openai"
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions.mjs"
 
 export const runtime: ServerRuntime = "edge"
+export const preferredRegion = ["iad1", "cle1", "pdx1", "sfo1"]
 
 export async function POST(request: Request) {
   const json = await request.json()


### PR DESCRIPTION
From [Vercel docs](https://vercel.com/docs/functions/configuring-functions/region#setting-regions-in-your-function):
> By default, Edge Functions execute in the region that is geographically closest to the incoming request,

This can cause issues when the Edge Functions execute in a region that is unsupported by OpenAI, like so:
![image](https://github.com/user-attachments/assets/8ab9d279-f5a8-4f27-a396-f4f9f3cede1a)
This has also been noted by Vercel themselves: https://vercel.com/changelog/openai-will-not-support-the-hong-kong-region-hkg1-for-functions

To fix, execute on the Edge Functions located in the US instead. This is also best practice acdg. to [OpenAI's docs](https://platform.openai.com/docs/guides/production-best-practices/improving-latencies#infrastructure) (and [Vercel's docs](https://vercel.com/docs/functions/configuring-functions/region#setting-regions-in-your-function:~:text=However%2C%20if%20your%20function%20depends%20on%20a%20data%20source%2C%20you%20may%20want%20it%20to%20be%20close%20to%20that%20source%20for%20fast%20responses.)) since that's where their servers are located anyway which will minimize roundtrip times. 