### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Chatbot UI
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=de) | 
+[Español](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=es) | 
+[français](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=fr) | 
+[日本語](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=ja) | 
+[한국어](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=ko) | 
+[Português](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=pt) | 
+[Русский](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=ru) | 
+[中文](https://www.readme-i18n.com/mckaywrigley/chatbot-ui?lang=zh)
+
 The open-source AI chat app for everyone.
 
 <img src="./public/readme/screenshot.png" alt="Chatbot UI" width="600">


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese. 

This update improves accessibility and project understanding for non-English speakers around the world.

The updated links can be previewed in my forked repository: https://github.com/dowithless/chatbot-ui/tree/patch-1