### PR TITLE
fix: avoid inadvertently committing unstaged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint:fix && npm run format:write && git add .
+git stash -k -u && npm run lint:fix && npm run format:write && git add . && git stash pop


### PR DESCRIPTION
Right now if you have a few modified files that you don't wish to commit, they get added anyway. 